### PR TITLE
Add path manually to COOKIE_Attributes. 

### DIFF
--- a/portability-api/src/main/java/org/dataportabilityproject/webapp/PortabilityApiUtils.java
+++ b/portability-api/src/main/java/org/dataportabilityproject/webapp/PortabilityApiUtils.java
@@ -55,7 +55,7 @@ public class PortabilityApiUtils {
    * SameSite=lax specification allows cookies to be sent by the browser on top level GET requests
    * and on requests from within the app.
    */
-  public final static String COOKIE_ATTRIBUTES = "; SameSite=lax";
+  public final static String COOKIE_ATTRIBUTES = "; Path=/; SameSite=lax";
 
   /**
    * Returns a URL representing the resource provided. TODO: remove hardcoded scheme - find a better


### PR DESCRIPTION
The way HttpCookie.toString() formats the path is incorrect and doesn't get parsed by the browser which in turn causes some cookies to not be attached to subsequent API requests (ex: encrypted flow tokens set by /callback* handler.
