### PR TITLE
Make Travis notify Slack

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,3 @@
 language: java
+notifications:
+    slack: portability:cQLXUZndgp7DcELNUwSkGUBm


### PR DESCRIPTION
It's configured to notify the #build-status channel

https://portability.slack.com/services/297899893366?updated=1#service_setup

For #22