### PR TITLE
Add ServiceMode enum for passing around instead of boolean isExport.

### DIFF
--- a/portability-api/src/main/java/org/dataportabilityproject/webapp/ConfigureHandler.java
+++ b/portability-api/src/main/java/org/dataportabilityproject/webapp/ConfigureHandler.java
@@ -32,6 +32,7 @@ import org.dataportabilityproject.job.JobUtils;
 import org.dataportabilityproject.job.PortabilityJob;
 import org.dataportabilityproject.job.PortabilityJobFactory;
 import org.dataportabilityproject.shared.PortableDataType;
+import org.dataportabilityproject.shared.ServiceMode;
 import org.dataportabilityproject.shared.auth.AuthFlowInitiator;
 import org.dataportabilityproject.shared.auth.OnlineAuthDataGenerator;
 import org.dataportabilityproject.shared.settings.CommonSettings;
@@ -42,6 +43,7 @@ import org.slf4j.LoggerFactory;
  * HttpHandler for the Configure service
  */
 final class ConfigureHandler implements HttpHandler {
+
   private static final Logger logger = LoggerFactory.getLogger(ConfigureHandler.class);
   private final ServiceProviderRegistry serviceProviderRegistry;
   private final JobDao jobDao;
@@ -92,11 +94,11 @@ final class ConfigureHandler implements HttpHandler {
       PortableDataType dataType = JobUtils.getDataType(dataTypeStr);
 
       String exportService = requestParameters.get(JsonKeys.EXPORT_SERVICE);
-      Preconditions.checkArgument(JobUtils.isValidService(exportService, true),
+      Preconditions.checkArgument(JobUtils.isValidService(exportService, ServiceMode.EXPORT),
           "Missing valid exportService: %s", exportService);
 
       String importService = requestParameters.get(JsonKeys.IMPORT_SERVICE);
-      Preconditions.checkArgument(JobUtils.isValidService(importService, false),
+      Preconditions.checkArgument(JobUtils.isValidService(importService, ServiceMode.IMPORT),
           "Missing valid importService: %s", importService);
 
       // Create a new job and persist
@@ -111,7 +113,7 @@ final class ConfigureHandler implements HttpHandler {
       PortabilityJob job;
       if (commonSettings.getEncryptedFlow()) {
         job = PortabilityApiUtils.lookupJobPendingAuthData(newJob.id(), jobDao);
-      }  else {
+      } else {
         job = PortabilityApiUtils.lookupJob(newJob.id(), jobDao);
       }
       Preconditions.checkState(job != null, "Job required");
@@ -135,7 +137,7 @@ final class ConfigureHandler implements HttpHandler {
       // is done in the SetupHandler in IMPORT mode
       if (authFlowInitiator.initialAuthData() != null) {
         PortabilityJob updatedJob = JobUtils
-            .setInitialAuthData(job, authFlowInitiator.initialAuthData(),  /*isExport=*/ true);
+            .setInitialAuthData(job, authFlowInitiator.initialAuthData(), ServiceMode.EXPORT);
         if (commonSettings.getEncryptedFlow()) {
           jobDao.updatePendingAuthDataJob(updatedJob);
         } else {
@@ -153,12 +155,16 @@ final class ConfigureHandler implements HttpHandler {
     return redirect; // to the auth url for the export service
   }
 
-  /** Create the initial job in initial state and persist in storage. */
-  private PortabilityJob createJob(PortableDataType dataType, String exportService, String importService)
+  /**
+   * Create the initial job in initial state and persist in storage.
+   */
+  private PortabilityJob createJob(PortableDataType dataType, String exportService,
+      String importService)
       throws IOException {
     PortabilityJob job = jobFactory.create(dataType, exportService, importService);
     if (commonSettings.getEncryptedFlow()) {
-      jobDao.insertJobInPendingAuthDataState(job); // This is the initial population of the row in storage
+      // This is the initial population of the row in storage
+      jobDao.insertJobInPendingAuthDataState(job); 
     } else {
       jobDao.insertJob(job);
     }

--- a/portability-api/src/main/java/org/dataportabilityproject/webapp/OauthCallbackHandler.java
+++ b/portability-api/src/main/java/org/dataportabilityproject/webapp/OauthCallbackHandler.java
@@ -32,6 +32,7 @@ import org.dataportabilityproject.job.JobUtils;
 import org.dataportabilityproject.job.PortabilityJob;
 import org.dataportabilityproject.shared.Config.Environment;
 import org.dataportabilityproject.shared.PortableDataType;
+import org.dataportabilityproject.shared.ServiceMode;
 import org.dataportabilityproject.shared.auth.AuthData;
 import org.dataportabilityproject.shared.auth.OnlineAuthDataGenerator;
 import org.dataportabilityproject.shared.settings.CommonSettings;
@@ -42,6 +43,7 @@ import org.slf4j.LoggerFactory;
  * HttpHandler for callbacks from Oauth1 authorization flow.
  */
 final class OauthCallbackHandler implements HttpHandler {
+
   private final Logger logger = LoggerFactory.getLogger(OauthCallbackHandler.class);
 
   private final ServiceProviderRegistry serviceProviderRegistry;
@@ -106,42 +108,48 @@ final class OauthCallbackHandler implements HttpHandler {
       PortabilityJob job;
       if (commonSettings.getEncryptedFlow()) {
         job = PortabilityApiUtils.lookupJobPendingAuthData(jobId, jobDao);
-      }  else {
+      } else {
         job = PortabilityApiUtils.lookupJob(jobId, jobDao);
       }
       PortableDataType dataType = JobUtils.getDataType(job.dataType());
 
-      boolean isExport = PortabilityApiUtils.isExport(
+      ServiceMode serviceMode = PortabilityApiUtils.getServiceMode(
           job,
           exchange.getRequestHeaders(),
           commonSettings.getEncryptedFlow());
 
       // TODO: Determine service from job or from authUrl path?
-      String service = isExport ? job.exportService() : job.importService();
+      String service =
+          serviceMode == ServiceMode.EXPORT ? job.exportService() : job.importService();
       Preconditions.checkState(!Strings.isNullOrEmpty(service),
-          "service not found, service: %s isExport: %b, job id: %s", service, isExport, jobId);
+          "service not found, service: %s serviceMode: %s, job id: %s", service, serviceMode,
+          jobId);
 
       // Obtain the ServiceProvider from the registry
       OnlineAuthDataGenerator generator = serviceProviderRegistry.getOnlineAuth(service, dataType);
 
       // Retrieve initial auth data, if it existed
-      AuthData initialAuthData = JobUtils.getInitialAuthData(job, isExport);
+      AuthData initialAuthData = JobUtils.getInitialAuthData(job, serviceMode);
       Preconditions
           .checkNotNull(initialAuthData, "Initial AuthData expected during Oauth 1.0 flow");
 
       // Generate and store auth data
-      AuthData authData = generator.generateAuthData(PortabilityApiFlags.baseApiUrl(), oauthVerifier, jobId, initialAuthData, null);
+      AuthData authData = generator
+          .generateAuthData(PortabilityApiFlags.baseApiUrl(), oauthVerifier, jobId, initialAuthData,
+              null);
 
       if (!commonSettings.getEncryptedFlow()) {
         // Update the job
-        PortabilityJob updatedJob = JobUtils.setAuthData(job, authData, isExport);
+        PortabilityJob updatedJob = JobUtils.setAuthData(job, authData, serviceMode);
         jobDao.updateJob(updatedJob);
       } else {
         // Set new cookie
-        cryptoHelper.encryptAndSetCookie(exchange.getResponseHeaders(), job.id(), isExport, authData);
+        cryptoHelper
+            .encryptAndSetCookie(exchange.getResponseHeaders(), job.id(), serviceMode, authData);
       }
 
-      redirect = PortabilityApiFlags.baseUrl() + (isExport ? "/next" : "/copy");
+      redirect =
+          PortabilityApiFlags.baseUrl() + ((serviceMode == ServiceMode.EXPORT) ? "/next" : "/copy");
     } catch (Exception e) {
       logger.error("Error handling request", e);
       throw e;

--- a/portability-api/src/main/java/org/dataportabilityproject/webapp/PortabilityApiUtils.java
+++ b/portability-api/src/main/java/org/dataportabilityproject/webapp/PortabilityApiUtils.java
@@ -36,6 +36,7 @@ import org.apache.http.NameValuePair;
 import org.apache.http.client.utils.URIBuilder;
 import org.dataportabilityproject.job.JobDao;
 import org.dataportabilityproject.job.PortabilityJob;
+import org.dataportabilityproject.shared.ServiceMode;
 import org.simpleframework.http.Cookie;
 import org.simpleframework.http.parse.CookieParser;
 import org.slf4j.Logger;
@@ -45,7 +46,6 @@ import org.slf4j.LoggerFactory;
  * Contains utility functions for use by the PortabilityServer HttpHandlers
  */
 public class PortabilityApiUtils {
-  private static final Logger logger = LoggerFactory.getLogger(PortabilityApiUtils.class);
 
   /**
    * Attributes to attach to all cookies set by the API - Since HttpCookie doesnt support adding
@@ -55,6 +55,7 @@ public class PortabilityApiUtils {
    * and on requests from within the app.
    */
   public final static String COOKIE_ATTRIBUTES = "; Path=/; SameSite=lax";
+  private static final Logger logger = LoggerFactory.getLogger(PortabilityApiUtils.class);
 
   /**
    * Returns a URL representing the resource provided. TODO: remove hardcoded scheme - find a better
@@ -155,14 +156,17 @@ public class PortabilityApiUtils {
     return job;
   }
 
-  /** Hack! For now, if we don't have export auth data, assume it's for export. */
-  public static boolean isExport(PortabilityJob job, Headers headers, boolean useEncryptedFlow) {
-    if(useEncryptedFlow) {
+  /**
+   * Hack! For now, if we don't have export auth data, assume it's for export.
+   */
+  public static ServiceMode getServiceMode(PortabilityJob job, Headers headers,
+      boolean useEncryptedFlow) {
+    if (useEncryptedFlow) {
       String exportAuthCookie = PortabilityApiUtils
           .getCookie(headers, JsonKeys.EXPORT_AUTH_DATA_COOKIE_KEY);
-      return (Strings.isNullOrEmpty(exportAuthCookie));
+      return (Strings.isNullOrEmpty(exportAuthCookie) ? ServiceMode.EXPORT : ServiceMode.IMPORT);
     } else {
-      return (null == job.exportAuthData());
+      return (null == job.exportAuthData() ? ServiceMode.EXPORT : ServiceMode.IMPORT);
     }
   }
 

--- a/portability-api/src/main/java/org/dataportabilityproject/webapp/SetupHandler.java
+++ b/portability-api/src/main/java/org/dataportabilityproject/webapp/SetupHandler.java
@@ -32,6 +32,7 @@ import org.dataportabilityproject.ServiceProviderRegistry;
 import org.dataportabilityproject.job.JobDao;
 import org.dataportabilityproject.job.JobUtils;
 import org.dataportabilityproject.job.PortabilityJob;
+import org.dataportabilityproject.shared.ServiceMode;
 import org.dataportabilityproject.shared.auth.AuthFlowInitiator;
 import org.dataportabilityproject.shared.auth.OnlineAuthDataGenerator;
 import org.dataportabilityproject.shared.settings.CommonSettings;
@@ -42,6 +43,7 @@ import org.slf4j.LoggerFactory;
  * Common logic for job setup handlers.
  */
 abstract class SetupHandler implements HttpHandler {
+
   private final Logger logger = LoggerFactory.getLogger(SetupHandler.class);
 
   private final JobDao jobDao;
@@ -136,9 +138,9 @@ abstract class SetupHandler implements HttpHandler {
     // This is done in ConfigureHandler as well for export services
     if (authFlowInitiator.initialAuthData() != null) {
       // Auth data is different for import and export. This is only valid for the /_/importSetup page,
-      // so isExport is set to false.
+      // so serviceMode is IMPORT
       PortabilityJob updatedJob = JobUtils
-          .setInitialAuthData(job, authFlowInitiator.initialAuthData(), /*isExport=*/false);
+          .setInitialAuthData(job, authFlowInitiator.initialAuthData(), ServiceMode.IMPORT);
       if (commonSettings.getEncryptedFlow()) {
         jobDao.updatePendingAuthDataJob(job);
       } else {

--- a/portability-core/src/main/java/org/dataportabilityproject/job/JobUtils.java
+++ b/portability-core/src/main/java/org/dataportabilityproject/job/JobUtils.java
@@ -22,6 +22,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.io.BaseEncoding;
 import org.dataportabilityproject.shared.PortableDataType;
+import org.dataportabilityproject.shared.ServiceMode;
 import org.dataportabilityproject.shared.auth.AuthData;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -42,32 +43,38 @@ public final class JobUtils {
     return BaseEncoding.base64Url().encode(job.id().getBytes(Charsets.UTF_8));
   }
 
-  /* Returns the initial auth data for export or import determined by the {@code isExport} param. */
-  public static AuthData getInitialAuthData(PortabilityJob job, boolean isExport) {
-    return isExport ? job.exportInitialAuthData() : job.importInitialAuthData();
+  /* Returns the initial auth data for export or import determined by the {@code serviceMode} param. */
+  public static AuthData getInitialAuthData(PortabilityJob job, ServiceMode serviceMode) {
+    return serviceMode == ServiceMode.EXPORT? job.exportInitialAuthData() : job.importInitialAuthData();
   }
 
   /* Sets the service in the correct field of the PortabilityJob */
   public static PortabilityJob setAuthData(PortabilityJob job, AuthData authData,
-      boolean isExportService) {
+      ServiceMode serviceMode) {
     PortabilityJob.Builder updatedJob = job.toBuilder();
-    if (isExportService) {
-      updatedJob.setExportAuthData(authData);
-    } else {
-      updatedJob.setImportAuthData(authData);
+    switch (serviceMode) {
+      case EXPORT:
+        updatedJob.setExportAuthData(authData);
+        break;
+      case IMPORT:
+        updatedJob.setImportAuthData(authData);
+        break;
     }
     return updatedJob.build();
   }
 
   /* Sets the service in the correct field of the PortabilityJob */
   public static PortabilityJob setInitialAuthData(PortabilityJob job, AuthData initialAuthData,
-      boolean isExport) {
-    logger.debug("Setting initialAuthData: {}, isExport:  {}", initialAuthData, isExport);
+      ServiceMode serviceMode) {
+    logger.debug("Setting initialAuthData: {}, serviceMode: {}", initialAuthData, serviceMode);
     PortabilityJob.Builder updatedJob = job.toBuilder();
-    if (isExport) {
-      updatedJob.setExportInitialAuthData(initialAuthData);
-    } else {
-      updatedJob.setImportInitialAuthData(initialAuthData);
+    switch (serviceMode) {
+      case EXPORT:
+        updatedJob.setExportInitialAuthData(initialAuthData);
+        break;
+      case IMPORT:
+        updatedJob.setImportInitialAuthData(initialAuthData);
+        break;
     }
     return updatedJob.build();
   }
@@ -85,7 +92,7 @@ public final class JobUtils {
   /**
    * Determines whether the current service is a valid service
    */
-  public static boolean isValidService(String serviceName, boolean isExport) {
+  public static boolean isValidService(String serviceName, ServiceMode serviceMode) {
     if (!Strings.isNullOrEmpty(serviceName)) {
       // TODO: Use service registry to validate the service is valid for import or export
       return true;

--- a/portability-core/src/main/java/org/dataportabilityproject/job/JobUtils.java
+++ b/portability-core/src/main/java/org/dataportabilityproject/job/JobUtils.java
@@ -45,7 +45,14 @@ public final class JobUtils {
 
   /* Returns the initial auth data for export or import determined by the {@code serviceMode} param. */
   public static AuthData getInitialAuthData(PortabilityJob job, ServiceMode serviceMode) {
-    return serviceMode == ServiceMode.EXPORT? job.exportInitialAuthData() : job.importInitialAuthData();
+    switch (serviceMode) {
+      case EXPORT:
+        return job.exportInitialAuthData();
+      case IMPORT:
+        return job.importInitialAuthData();
+      default:
+        throw new IllegalArgumentException("Unsupported service mode: " + serviceMode);
+    }
   }
 
   /* Sets the service in the correct field of the PortabilityJob */
@@ -59,6 +66,8 @@ public final class JobUtils {
       case IMPORT:
         updatedJob.setImportAuthData(authData);
         break;
+      default:
+        throw new IllegalArgumentException("Unsupported service mode: " + serviceMode);
     }
     return updatedJob.build();
   }
@@ -75,6 +84,8 @@ public final class JobUtils {
       case IMPORT:
         updatedJob.setImportInitialAuthData(initialAuthData);
         break;
+      default:
+        throw new IllegalArgumentException("Unsupported service mode: " + serviceMode);
     }
     return updatedJob.build();
   }

--- a/portability-core/src/main/java/org/dataportabilityproject/shared/ServiceMode.java
+++ b/portability-core/src/main/java/org/dataportabilityproject/shared/ServiceMode.java
@@ -1,7 +1,7 @@
 package org.dataportabilityproject.shared;
 
 /**
- * The possible service modes for each authorization
+ * The possible service modes for transferring data.
  */
 public enum ServiceMode {
   IMPORT,

--- a/portability-core/src/main/java/org/dataportabilityproject/shared/ServiceMode.java
+++ b/portability-core/src/main/java/org/dataportabilityproject/shared/ServiceMode.java
@@ -1,0 +1,9 @@
+package org.dataportabilityproject.shared;
+
+/**
+ * The possible service modes for each authorization
+ */
+public enum ServiceMode {
+  IMPORT,
+  EXPORT
+}

--- a/portability-core/src/test/java/org/dataportabilityproject/job/JobUtilsTest.java
+++ b/portability-core/src/test/java/org/dataportabilityproject/job/JobUtilsTest.java
@@ -1,7 +1,10 @@
 package org.dataportabilityproject.job;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.dataportabilityproject.shared.ServiceMode.EXPORT;
+import static org.dataportabilityproject.shared.ServiceMode.IMPORT;
 
+import org.dataportabilityproject.shared.ServiceMode;
 import org.dataportabilityproject.shared.auth.AuthData;
 import org.dataportabilityproject.shared.auth.PasswordAuthData;
 import org.dataportabilityproject.shared.auth.TokenSecretAuthData;
@@ -19,29 +22,25 @@ public class JobUtilsTest {
 
   @Test
   public void passwordAuthDataRoundTrip() throws Exception {
-    boolean isExport = false;
     PortabilityJob importJob = PortabilityJob.builder().setId("id").build();
     AuthData authData = PasswordAuthData.create("myUsername", "myPassword");
     assertThat(JobUtils.getInitialAuthData(
-        JobUtils.setInitialAuthData(importJob, authData, isExport), isExport)).isEqualTo(authData);
+        JobUtils.setInitialAuthData(importJob, authData, IMPORT), IMPORT)).isEqualTo(authData);
 
-    isExport = true;
     PortabilityJob exportJob = PortabilityJob.builder().setId("id").build();
     assertThat(JobUtils.getInitialAuthData(
-        JobUtils.setInitialAuthData(exportJob, authData, isExport), isExport)).isEqualTo(authData);
+        JobUtils.setInitialAuthData(exportJob, authData, EXPORT), EXPORT)).isEqualTo(authData);
   }
 
   @Test
   public void tokenAuthDataRoundTrip() throws Exception {
-    boolean isExport = false;
     PortabilityJob importJob = PortabilityJob.builder().setId("id").build();
     AuthData authData = TokenSecretAuthData.create("myToken", "mySecret");
     assertThat(JobUtils.getInitialAuthData(
-        JobUtils.setInitialAuthData(importJob, authData, isExport), isExport)).isEqualTo(authData);
+        JobUtils.setInitialAuthData(importJob, authData, IMPORT), IMPORT)).isEqualTo(authData);
 
-    isExport = true;
     PortabilityJob exportJob = PortabilityJob.builder().setId("id").build();
     assertThat(JobUtils.getInitialAuthData(
-        JobUtils.setInitialAuthData(exportJob, authData, isExport), isExport)).isEqualTo(authData);
+        JobUtils.setInitialAuthData(exportJob, authData, EXPORT), EXPORT)).isEqualTo(authData);
   }
 }


### PR DESCRIPTION
This is in prep for limiting Oauth scopes #25  - idea is in addition to passing dataType to serviceProviderRegistry.getOnlineAuthDataGenerator, we would pass in the service mode.  Then each service provider can determine what generator to return based on the pair. 