### PR TITLE
Fix local environment pointing to GCP & update documentation

### DIFF
--- a/config/gcp/README.md
+++ b/config/gcp/README.md
@@ -27,7 +27,11 @@ is controlled with the _cloud=LOCAL_ flag in
 We also provide functionality for local instances to point to a test GCP
 project by specifying _cloud=GOOGLE_. The project this points to, as
 well as credentials to access it, are configured in our Docker image
-build [script](build_and_upload_docker_image.sh).
+build [script](build_and_upload_docker_image.sh). The project should be
+specified in LOCAL_GCP_PROJECT in init_common_vars.sh. Credentials
+for that project's service account should be accessed from API >
+Credentials > service account credentials in GoogleCloudPlatform and
+copied into config/gcp/service_account_credentials.json locally.
 
 For more information on running locally see
 [Developer documentation](../../Documentation/Developer.md).

--- a/config/gcp/build_and_upload_docker_image.sh
+++ b/config/gcp/build_and_upload_docker_image.sh
@@ -98,8 +98,6 @@ Continue? (Y/n): " response
       echo "Aborting"
       exit 0
     fi
-    # This is a test project. Only use test projects here!
-    LOCAL_GCP_PROJECT="world-takeout-test"
     LOCAL_DEBUG_SETTINGS=$LOCAL_DEBUG_SETTINGS"
 COPY $CREDS_FILE /service_acct_creds.json
 ENV GOOGLE_PROJECT_ID=$LOCAL_GCP_PROJECT

--- a/config/gcp/init_project_vars_example.sh
+++ b/config/gcp/init_project_vars_example.sh
@@ -6,3 +6,6 @@ ORGANIZATION_ID=123456 #ID for your organization in GCP project
 BILLING_ACCOUNT_ID=123-456
 BASE_PROJECT_ID="acme-portability"
 OWNERS="\"user:alice@acme.com\",\"user:bob@acme.com\""
+# Optional: Test project when running locally and pointing to a GCP project.
+# Only use test projects here! Only used when cloud=GOOGLE in local/common.yaml.
+LOCAL_GCP_PROJECT="acme-portability-qa"

--- a/portability-core/src/main/java/org/dataportabilityproject/PortabilityCoreModule.java
+++ b/portability-core/src/main/java/org/dataportabilityproject/PortabilityCoreModule.java
@@ -28,6 +28,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import org.dataportabilityproject.cloud.SupportedCloud;
 import org.dataportabilityproject.cloud.google.GoogleCloudFactory;
+import org.dataportabilityproject.cloud.google.GoogleCloudModule;
 import org.dataportabilityproject.cloud.interfaces.CloudFactory;
 import org.dataportabilityproject.cloud.local.LocalCloudFactory;
 import org.dataportabilityproject.job.JWTTokenManager;
@@ -44,6 +45,11 @@ import org.dataportabilityproject.shared.local.LocalAppCredentialFactory;
 import org.dataportabilityproject.shared.settings.CommonSettings;
 
 public final class PortabilityCoreModule extends AbstractModule {
+  private final CommonSettings commonSettings;
+
+  public PortabilityCoreModule() {
+    this.commonSettings = getCommonSettings();
+  }
 
   @Override
   protected void configure() {
@@ -54,11 +60,19 @@ public final class PortabilityCoreModule extends AbstractModule {
     install(new MicrosoftModule());
     install(new RememberTheMilkModule());
     install(new SmugmugModule());
+
+    if (commonSettings.getCloud() == SupportedCloud.GOOGLE) {
+      install(new GoogleCloudModule());
+    }
   }
 
   @Singleton
   @Provides
   CommonSettings provideCommonSettings() {
+    return commonSettings;
+  }
+
+  private CommonSettings getCommonSettings() {
     ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
     try {
       InputStream in =
@@ -85,7 +99,6 @@ public final class PortabilityCoreModule extends AbstractModule {
       throw new UnsupportedOperationException(commonSettings.getCloud() + " is not supported yet.");
     }
   }
-
 
   @Provides
   AppCredentialFactory provideAppCredentialFactory(

--- a/portability-core/src/main/java/org/dataportabilityproject/cloud/google/GoogleBucketStore.java
+++ b/portability-core/src/main/java/org/dataportabilityproject/cloud/google/GoogleBucketStore.java
@@ -26,9 +26,11 @@ final class GoogleBucketStore implements BucketStore {
   private Storage storage;
 
   @Inject
-  GoogleBucketStore(GoogleCredentials googleCredentials) {
+  GoogleBucketStore(
+      GoogleCredentials googleCredentials,
+      ProjectId projectId) {
     storage = StorageOptions.newBuilder()
-        .setProjectId(GoogleCloudFactory.getGoogleProjectId())
+        .setProjectId(projectId.getProjectId())
         .setCredentials(googleCredentials)
         .build().getService();
   }

--- a/portability-core/src/main/java/org/dataportabilityproject/cloud/google/GoogleCloudFactory.java
+++ b/portability-core/src/main/java/org/dataportabilityproject/cloud/google/GoogleCloudFactory.java
@@ -23,8 +23,6 @@ import com.google.cloud.datastore.Key;
 import com.google.cloud.datastore.Query;
 import com.google.cloud.datastore.QueryResults;
 import com.google.cloud.datastore.StructuredQuery.PropertyFilter;
-import com.google.common.base.Preconditions;
-import com.google.common.base.Strings;
 import javax.inject.Inject;
 import org.dataportabilityproject.cloud.interfaces.BucketStore;
 import org.dataportabilityproject.cloud.interfaces.CloudFactory;
@@ -33,29 +31,28 @@ import org.dataportabilityproject.cloud.interfaces.JobDataCache;
 import org.dataportabilityproject.cloud.interfaces.PersistentKeyValueStore;
 
 public final class GoogleCloudFactory implements CloudFactory {
-  // Lazy init this in case we are running a different cloud than Google, in which case this class
-  // won't be used and the environment variable this is set from won't be available.
-  private static String PROJECT_ID;
-
   private final Datastore datastore;
   private final PersistentKeyValueStore persistentKeyValueStore;
   private final CryptoKeyManagementSystem cryptoKeyManagementSystem;
   private final BucketStore bucketStore;
+  private final String projectId;
 
   @Inject
   public GoogleCloudFactory(
       GoogleBucketStore googleBucketStore,
       GoogleCredentials googleCredentials,
-      GoogleCryptoKeyManagementSystem googleCryptoKeyManagementSystem) {
+      GoogleCryptoKeyManagementSystem googleCryptoKeyManagementSystem,
+      ProjectId projectId) {
     this.datastore = DatastoreOptions
         .newBuilder()
-        .setProjectId(getGoogleProjectId())
+        .setProjectId(projectId.getProjectId())
         .setCredentials(googleCredentials)
         .build()
         .getService();
     this.persistentKeyValueStore = new GooglePersistentKeyValueStore(datastore);
     this.cryptoKeyManagementSystem = googleCryptoKeyManagementSystem;
     this.bucketStore = googleBucketStore;
+    this.projectId = projectId.getProjectId();
   }
 
   @Override
@@ -94,34 +91,6 @@ public final class GoogleCloudFactory implements CloudFactory {
    */
   @Override
   public String getProjectId() {
-    return getGoogleProjectId();
-  }
-
-  /**
-   * Get project ID from environment variable and validate it is set.
-   *
-   * <p>Exposed as package private so Google classes in this package may use this directly without
-   * needing to obtain a CloudFactory instance.
-   *
-   * @return project ID
-   * @throws IllegalArgumentException if project ID is unset
-   */
-  static String getGoogleProjectId() throws IllegalArgumentException {
-    if (PROJECT_ID != null) {
-      return PROJECT_ID;
-    }
-    String tempProjectId;
-    try {
-      tempProjectId = System.getenv("GOOGLE_PROJECT_ID");
-    } catch (NullPointerException e) {
-      throw new IllegalArgumentException("Need to specify a project ID when using Google Cloud. "
-          + "This should be exposed as an environment variable by Kubernetes, see "
-          + "k8s/api-deployment.yaml");
-    }
-    Preconditions.checkArgument(!Strings.isNullOrEmpty(tempProjectId), "Need to specify a project "
-        + "ID when using Google Cloud. This should be exposed as an environment variable by "
-        + "Kubernetes, see k8s/api-deployment.yaml");
-    PROJECT_ID = tempProjectId.toLowerCase();
-    return PROJECT_ID;
+    return projectId;
   }
 }

--- a/portability-core/src/main/java/org/dataportabilityproject/cloud/google/GoogleCloudModule.java
+++ b/portability-core/src/main/java/org/dataportabilityproject/cloud/google/GoogleCloudModule.java
@@ -18,6 +18,8 @@ package org.dataportabilityproject.cloud.google;
 import static org.dataportabilityproject.shared.Config.Environment.LOCAL;
 
 import com.google.auth.oauth2.GoogleCredentials;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
 import com.google.inject.AbstractModule;
 import com.google.inject.Inject;
 import com.google.inject.Provides;
@@ -28,7 +30,6 @@ public class GoogleCloudModule extends AbstractModule {
 
   @Override
   protected void configure() {
-
   }
 
   @Provides
@@ -59,4 +60,23 @@ public class GoogleCloudModule extends AbstractModule {
     }
   }
 
+  /**
+   * Get project ID from environment variable and validate it is set.
+   *
+   * @throws IllegalArgumentException if project ID is unset
+   */
+  @Provides ProjectId getProjectId() {
+    String projectId;
+    try {
+      projectId = System.getenv("GOOGLE_PROJECT_ID");
+    } catch (NullPointerException e) {
+      throw new IllegalArgumentException("Need to specify a project ID when using Google Cloud. "
+          + "This should be exposed as an environment variable by Kubernetes, see "
+          + "k8s/api-deployment.yaml");
+    }
+    Preconditions.checkArgument(!Strings.isNullOrEmpty(projectId), "Need to specify a project "
+        + "ID when using Google Cloud. This should be exposed as an environment variable by "
+        + "Kubernetes, see k8s/api-deployment.yaml");
+    return new ProjectId(projectId.toLowerCase());
+  }
 }

--- a/portability-core/src/main/java/org/dataportabilityproject/cloud/google/ProjectId.java
+++ b/portability-core/src/main/java/org/dataportabilityproject/cloud/google/ProjectId.java
@@ -1,0 +1,24 @@
+package org.dataportabilityproject.cloud.google;
+
+import com.google.inject.Inject;
+
+/**
+ * Wrapper class for a Google Cloud Platform project ID.
+ *
+ * <p>This class exists so that we can inject ProjectId into Google implementation classes without
+ * forcing Guice to eagerly eval Provider<GoogleCloudFactory> when not using cloud=GOOGLE. i.e. if
+ * we just bound the project ID as a String directly ("@ProjectId String projectId") via
+ * bind(String.toClass).annotatedWith(ProjectId.class).toInstance(...), that causes eager init.
+ */
+class ProjectId {
+  private final String projectId;
+
+  @Inject
+  public ProjectId(String projectId) {
+    this.projectId = projectId;
+  }
+
+  public String getProjectId() {
+    return projectId;
+  }
+}

--- a/portability-core/src/main/java/org/dataportabilityproject/shared/CloudAppCredentialFactory.java
+++ b/portability-core/src/main/java/org/dataportabilityproject/shared/CloudAppCredentialFactory.java
@@ -18,16 +18,33 @@ package org.dataportabilityproject.shared;
 import static com.google.common.base.Preconditions.checkState;
 
 import com.google.common.base.Strings;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
 import com.google.inject.Inject;
+import com.google.inject.Singleton;
 import java.io.IOException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 import org.dataportabilityproject.cloud.interfaces.BucketStore;
 import org.dataportabilityproject.cloud.interfaces.CloudFactory;
 import org.dataportabilityproject.cloud.interfaces.CryptoKeyManagementSystem;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@Singleton
 public class CloudAppCredentialFactory implements AppCredentialFactory {
   static final Logger logger = LoggerFactory.getLogger(AppCredentials.class);
+
+  /**
+   * Store keys and secrets in a cache so we can reduce load on cloud storage / KMS when
+   * reading keys and reading/decrypting secrets several times on startup.
+   *
+   * <p>Set the cache to reload keys/secrets periodically so that in the event of a key/secret being
+   * compromised, we can update them without restarting our servers.
+   */
+  private LoadingCache<String, String> keys;
+  private LoadingCache<String, String> secrets;
 
   private static final String BUCKET_NAME_PREFIX = "app-data-";
   private static final String KEYS_DIR = "keys/";
@@ -38,24 +55,59 @@ public class CloudAppCredentialFactory implements AppCredentialFactory {
       + "keyRings/portability_secrets/cryptoKeys/portability_secrets_key";
 
   private final CloudFactory cloudFactory;
+  private final BucketStore bucketStore;
+  private final CryptoKeyManagementSystem cryptoKeyManagementSystem;
 
   @Inject
   CloudAppCredentialFactory(CloudFactory cloudFactory) {
     this.cloudFactory = cloudFactory;
+    this.bucketStore = cloudFactory.getBucketStore();
+    this.cryptoKeyManagementSystem = cloudFactory.getCryptoKeyManagementSystem();
+    this.keys = CacheBuilder.newBuilder().expireAfterWrite(10, TimeUnit.MINUTES).build(
+        new CacheLoader<String, String>() {
+          @Override
+          public String load(String key) throws Exception {
+            return lookupKey(key);
+          }
+        });
+    this.secrets = CacheBuilder.newBuilder().expireAfterWrite(10, TimeUnit.MINUTES).build(
+        new CacheLoader<String, String>() {
+          @Override
+          public String load(String key) throws Exception {
+            return lookupSecret(key);
+          }
+        });
   }
 
   @Override
   public AppCredentials lookupAndCreate(String keyName, String secretName) throws IOException {
+    String key;
+    String secret;
+    try {
+      key = keys.get(keyName);
+      secret = secrets.get(secretName);
+    } catch (ExecutionException e) {
+      throw new IOException("Couldn't lookup key or secret", e);
+    }
+
+    return AppCredentials.create(key, secret);
+  }
+
+  private String lookupKey(String keyName) {
     String projectId = cloudFactory.getProjectId();
     String bucketName = BUCKET_NAME_PREFIX + projectId;
-    BucketStore bucketStore = cloudFactory.getBucketStore();
-    CryptoKeyManagementSystem keyManagementSystem = cloudFactory.getCryptoKeyManagementSystem();
-
     String keyLocation = KEYS_DIR + keyName + KEY_EXTENSION;
     logger.debug("Getting key {} (blob {}) from bucket {}", keyName, keyLocation, bucketName);
     byte[] rawKeyBytes = bucketStore.getBlob(bucketName, keyLocation);
     String key = new String(rawKeyBytes);
     checkState(!Strings.isNullOrEmpty(key), "Couldn't lookup: " + keyName);
+    return key;
+  }
+
+  private String lookupSecret(String secretName) throws IOException {
+    String projectId = cloudFactory.getProjectId();
+    String bucketName = BUCKET_NAME_PREFIX + projectId;
+    BucketStore bucketStore = cloudFactory.getBucketStore();
     String secretLocation = SECRETS_DIR + secretName + SECRET_EXTENSION;
     logger.debug("Getting secret {} (blob {}) from bucket {}", secretName, secretLocation,
         bucketName);
@@ -64,9 +116,8 @@ public class CloudAppCredentialFactory implements AppCredentialFactory {
     logger.debug("Decrypting secret with crypto key {}", cryptoKeyName);
 
     String secret =
-        new String(keyManagementSystem.decrypt(cryptoKeyName, encryptedSecret));
-    checkState(!Strings.isNullOrEmpty(key), "Couldn't lookup: " + secretName);
-    return AppCredentials.create(key, secret);
-
+        new String(cryptoKeyManagementSystem.decrypt(cryptoKeyName, encryptedSecret));
+    checkState(!Strings.isNullOrEmpty(secret), "Couldn't lookup: " + secretName);
+    return secret;
   }
 }

--- a/portability-core/src/main/java/org/dataportabilityproject/shared/settings/CommonSettings.java
+++ b/portability-core/src/main/java/org/dataportabilityproject/shared/settings/CommonSettings.java
@@ -60,9 +60,10 @@ public class CommonSettings {
       // locally and connecting to GCP
       String googleProjectId = System.getenv("GOOGLE_PROJECT_ID");
       Preconditions.checkArgument(
-          googleProjectId.endsWith("-local") || googleProjectId.endsWith("-test"),
+          googleProjectId.endsWith("-local") || googleProjectId.endsWith("-test")
+              || googleProjectId.endsWith("-qa"),
           "Invalid project to connect to with env=LOCAL. " + googleProjectId + " doesn't appear to"
-              + " be a local/test project since it doesn't end in -local or -test. Aborting");
+              + " be a local/test project since it doesn't end in -local, -test, or -qa. Aborting");
     }
   }
 


### PR DESCRIPTION
Now that we're on Guice, also inject project ID into Google implementation classes instead of using static util method

Store keys & secrets in a LoadingCache since they were being read a ton of times on startup

Tested locally pointing to cloud=GOOGLE, and pointing to LOCAL verified we don't initialize any of the Google impls.