### PR TITLE
Update InstagramServiceProvider to return auth based on serviceMode.

### DIFF
--- a/portability-core/src/main/java/org/dataportabilityproject/serviceProviders/instagram/InstagramServiceProvider.java
+++ b/portability-core/src/main/java/org/dataportabilityproject/serviceProviders/instagram/InstagramServiceProvider.java
@@ -15,6 +15,7 @@
  */
 package org.dataportabilityproject.serviceProviders.instagram;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Inject;
 import java.io.IOException;
@@ -25,14 +26,16 @@ import org.dataportabilityproject.dataModels.Importer;
 import org.dataportabilityproject.shared.AppCredentialFactory;
 import org.dataportabilityproject.shared.AppCredentials;
 import org.dataportabilityproject.shared.PortableDataType;
+import org.dataportabilityproject.shared.ServiceMode;
 import org.dataportabilityproject.shared.ServiceProvider;
 import org.dataportabilityproject.shared.auth.AuthData;
 import org.dataportabilityproject.shared.auth.OfflineAuthDataGenerator;
 import org.dataportabilityproject.shared.auth.OnlineAuthDataGenerator;
 
 final class InstagramServiceProvider implements ServiceProvider {
-  private static final ImmutableList<String> SCOPES = ImmutableList.of(
-      "basic"); // See https://www.instagram.com/developer/authorization/
+  // Instagram only offers basic scope for reading user's profiles. There is no "write" scope.
+  // See https://www.instagram.com/developer/authorization/
+  private static final ImmutableList<String> SCOPES = ImmutableList.of("basic");
   private final InstagramAuth instagramAuth;
 
   @Inject
@@ -59,12 +62,14 @@ final class InstagramServiceProvider implements ServiceProvider {
   }
 
   @Override
-  public OfflineAuthDataGenerator getOfflineAuthDataGenerator(PortableDataType dataType) {
+  public OfflineAuthDataGenerator getOfflineAuthDataGenerator(PortableDataType dataType, ServiceMode serviceMode) {
+    Preconditions.checkArgument(serviceMode == ServiceMode.EXPORT, "IMPORT not supported by Instagram");
     return instagramAuth;
   }
 
   @Override
-  public OnlineAuthDataGenerator getOnlineAuthDataGenerator(PortableDataType dataType) {
+  public OnlineAuthDataGenerator getOnlineAuthDataGenerator(PortableDataType dataType, ServiceMode serviceMode) {
+    Preconditions.checkArgument(serviceMode == ServiceMode.EXPORT, "IMPORT not supported by Instagram");
     return instagramAuth;
   }
 

--- a/portability-core/src/main/java/org/dataportabilityproject/serviceProviders/instagram/InstagramServiceProvider.java
+++ b/portability-core/src/main/java/org/dataportabilityproject/serviceProviders/instagram/InstagramServiceProvider.java
@@ -36,6 +36,9 @@ final class InstagramServiceProvider implements ServiceProvider {
   // Instagram only offers basic scope for reading user's profiles. There is no "write" scope.
   // See https://www.instagram.com/developer/authorization/
   private static final ImmutableList<String> SCOPES = ImmutableList.of("basic");
+  private final ImmutableList<PortableDataType> exportTypes = ImmutableList
+      .of(PortableDataType.PHOTOS);
+
   private final InstagramAuth instagramAuth;
 
   @Inject
@@ -52,7 +55,7 @@ final class InstagramServiceProvider implements ServiceProvider {
 
   @Override
   public ImmutableList<PortableDataType> getExportTypes() {
-    return ImmutableList.of(PortableDataType.PHOTOS);
+    return exportTypes;
   }
 
   @Override
@@ -64,12 +67,18 @@ final class InstagramServiceProvider implements ServiceProvider {
   @Override
   public OfflineAuthDataGenerator getOfflineAuthDataGenerator(PortableDataType dataType, ServiceMode serviceMode) {
     Preconditions.checkArgument(serviceMode == ServiceMode.EXPORT, "IMPORT not supported by Instagram");
+    Preconditions
+        .checkArgument(exportTypes.contains(dataType), "DataType %s not supported by Instagram",
+            dataType);
     return instagramAuth;
   }
 
   @Override
   public OnlineAuthDataGenerator getOnlineAuthDataGenerator(PortableDataType dataType, ServiceMode serviceMode) {
     Preconditions.checkArgument(serviceMode == ServiceMode.EXPORT, "IMPORT not supported by Instagram");
+    Preconditions
+        .checkArgument(exportTypes.contains(dataType), "DataType %s not supported by Instagram",
+            dataType);
     return instagramAuth;
   }
 
@@ -78,10 +87,9 @@ final class InstagramServiceProvider implements ServiceProvider {
       PortableDataType type,
       AuthData authData,
       JobDataCache jobDataCache) throws IOException {
-    if (type == PortableDataType.PHOTOS) {
-      return new InstagramPhotoService(((InstagramOauthData) authData));
-    }
-    throw new IllegalStateException("Instagram doesn't support exporting: " + type);
+    Preconditions
+        .checkArgument(exportTypes.contains(type), "Instagram doesn't support exporting %s", type);
+    return new InstagramPhotoService(((InstagramOauthData) authData));
   }
 
   @Override

--- a/portability-core/src/main/java/org/dataportabilityproject/serviceProviders/instagram/InstagramServiceProvider.java
+++ b/portability-core/src/main/java/org/dataportabilityproject/serviceProviders/instagram/InstagramServiceProvider.java
@@ -36,7 +36,7 @@ final class InstagramServiceProvider implements ServiceProvider {
   // Instagram only offers basic scope for reading user's profiles. There is no "write" scope.
   // See https://www.instagram.com/developer/authorization/
   private static final ImmutableList<String> SCOPES = ImmutableList.of("basic");
-  private final ImmutableList<PortableDataType> exportTypes = ImmutableList
+  private static final ImmutableList<PortableDataType> EXPORT_TYPES = ImmutableList
       .of(PortableDataType.PHOTOS);
 
   private final InstagramAuth instagramAuth;
@@ -55,7 +55,7 @@ final class InstagramServiceProvider implements ServiceProvider {
 
   @Override
   public ImmutableList<PortableDataType> getExportTypes() {
-    return exportTypes;
+    return EXPORT_TYPES;
   }
 
   @Override
@@ -68,7 +68,8 @@ final class InstagramServiceProvider implements ServiceProvider {
   public OfflineAuthDataGenerator getOfflineAuthDataGenerator(PortableDataType dataType, ServiceMode serviceMode) {
     Preconditions.checkArgument(serviceMode == ServiceMode.EXPORT, "IMPORT not supported by Instagram");
     Preconditions
-        .checkArgument(exportTypes.contains(dataType), "DataType %s not supported by Instagram",
+        .checkArgument(EXPORT_TYPES.contains(dataType),
+            "Export of type [%s] is not supported by Instagram",
             dataType);
     return instagramAuth;
   }
@@ -77,7 +78,8 @@ final class InstagramServiceProvider implements ServiceProvider {
   public OnlineAuthDataGenerator getOnlineAuthDataGenerator(PortableDataType dataType, ServiceMode serviceMode) {
     Preconditions.checkArgument(serviceMode == ServiceMode.EXPORT, "IMPORT not supported by Instagram");
     Preconditions
-        .checkArgument(exportTypes.contains(dataType), "DataType %s not supported by Instagram",
+        .checkArgument(EXPORT_TYPES.contains(dataType),
+            "Export of type [%s] is not supported by Instagram",
             dataType);
     return instagramAuth;
   }
@@ -88,7 +90,8 @@ final class InstagramServiceProvider implements ServiceProvider {
       AuthData authData,
       JobDataCache jobDataCache) throws IOException {
     Preconditions
-        .checkArgument(exportTypes.contains(type), "Instagram doesn't support exporting %s", type);
+        .checkArgument(EXPORT_TYPES.contains(type),
+            "Export of type [%s] is not supported by Instagram", type);
     return new InstagramPhotoService(((InstagramOauthData) authData));
   }
 


### PR DESCRIPTION
(Instagram currently only supports IMPORT mode so this is functionally a
no-op). #25 