### PR TITLE
Slight refactor to make FlickrServiceProvider more like other Oauth1 providers (Smugmug and RememberTheMilk).

### DIFF
--- a/portability-core/src/main/java/org/dataportabilityproject/serviceProviders/flickr/FlickrServiceProvider.java
+++ b/portability-core/src/main/java/org/dataportabilityproject/serviceProviders/flickr/FlickrServiceProvider.java
@@ -20,6 +20,8 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Inject;
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 import org.dataportabilityproject.cloud.interfaces.JobDataCache;
 import org.dataportabilityproject.dataModels.DataModel;
 import org.dataportabilityproject.dataModels.Exporter;
@@ -38,16 +40,14 @@ import org.dataportabilityproject.shared.auth.OnlineAuthDataGenerator;
  */
 final class FlickrServiceProvider implements ServiceProvider {
     private final AppCredentials appCredentials;
-    private final FlickrAuth importAuth;
-    private final FlickrAuth exportAuth;
-    private final ImmutableList<PortableDataType> dataTypes = ImmutableList
+
+    private final static ImmutableList<PortableDataType> SUPPORTED_DATA_TYPES = ImmutableList
         .of(PortableDataType.PHOTOS);
+    private final static Map<ServiceMode, FlickrAuth> AUTH_MAP = new HashMap<>();
 
     @Inject
     FlickrServiceProvider(AppCredentialFactory appCredentialFactory) throws IOException {
         this.appCredentials = appCredentialFactory.lookupAndCreate("FLICKR_KEY", "FLICKR_SECRET");
-        this.importAuth = new FlickrAuth(appCredentials, ServiceMode.IMPORT);
-        this.exportAuth = new FlickrAuth(appCredentials, ServiceMode.EXPORT);
     }
 
     @Override public String getName() {
@@ -55,53 +55,31 @@ final class FlickrServiceProvider implements ServiceProvider {
     }
 
     @Override public ImmutableList<PortableDataType> getExportTypes() {
-        return dataTypes;
+        return SUPPORTED_DATA_TYPES;
     }
 
     @Override public ImmutableList<PortableDataType> getImportTypes() {
-        return dataTypes;
+        return SUPPORTED_DATA_TYPES;
     }
 
     @Override // OfflineDataGenerator
     public OfflineAuthDataGenerator getOfflineAuthDataGenerator(PortableDataType dataType, ServiceMode serviceMode) {
-        Preconditions.checkArgument(dataTypes.contains(dataType),
-                "Provided dataType not supported: " + dataType);
-
-        switch (serviceMode) {
-            case IMPORT:
-                return importAuth;
-            case EXPORT:
-                return exportAuth;
-            default:
-                throw new IllegalArgumentException("ServiceMode not supported: " + serviceMode);
-        }
+        return lookupAndCreateAuth(dataType, serviceMode);
     }
 
     @Override
     public OnlineAuthDataGenerator getOnlineAuthDataGenerator(PortableDataType dataType,
         ServiceMode serviceMode) {
-        Preconditions.checkArgument(dataTypes.contains(dataType),
-            "Provided dataType not supported: " + dataType);
-
-        switch (serviceMode) {
-            case IMPORT:
-                return importAuth;
-            case EXPORT:
-                return exportAuth;
-            default:
-                throw new IllegalArgumentException("ServiceMode not supported: " + serviceMode);
-        }
+        return lookupAndCreateAuth(dataType, serviceMode);
     }
 
     @Override public Exporter<? extends DataModel> getExporter(
         PortableDataType type,
         AuthData authData,
         JobDataCache jobDataCache) throws IOException {
-        if (type != PortableDataType.PHOTOS) {
-            throw new IllegalArgumentException("Type " + type + " is not supported");
-        }
 
-        return getInstanceOfService(authData, jobDataCache, ServiceMode.EXPORT);
+        return getInstanceOfService(authData, jobDataCache,
+            lookupAndCreateAuth(type, ServiceMode.EXPORT));
     }
 
     @Override public Importer<? extends DataModel> getImporter(
@@ -112,28 +90,27 @@ final class FlickrServiceProvider implements ServiceProvider {
             throw new IllegalArgumentException("Type " + type + " is not supported");
         }
 
-        return getInstanceOfService(authData, jobDataCache, ServiceMode.IMPORT);
+        return getInstanceOfService(authData, jobDataCache,
+            lookupAndCreateAuth(type, ServiceMode.IMPORT));
     }
 
     private synchronized FlickrPhotoService getInstanceOfService(
         AuthData authData,
-        JobDataCache jobDataCache, ServiceMode serviceMode) throws IOException {
-        Auth auth;
-
-        switch (serviceMode) {
-            case EXPORT:
-                auth = exportAuth.getAuth(authData);
-                break;
-            case IMPORT:
-                auth = importAuth.getAuth(authData);
-                break;
-            default:
-                throw new IllegalArgumentException("ServiceMode not supported: " + serviceMode);
-        }
+        JobDataCache jobDataCache, FlickrAuth flickrAuth) throws IOException {
+        Auth auth = flickrAuth.getAuth(authData);
 
         return new FlickrPhotoService(
                 appCredentials,
                 auth,
                 jobDataCache);
+    }
+
+    private FlickrAuth lookupAndCreateAuth(PortableDataType dataType, ServiceMode serviceMode) {
+        Preconditions.checkArgument(SUPPORTED_DATA_TYPES.contains(dataType),
+            "[%s] mode not supported for dataType [%s]", serviceMode, dataType);
+        if (!AUTH_MAP.containsKey(serviceMode)) {
+            AUTH_MAP.put(serviceMode, new FlickrAuth(appCredentials, serviceMode));
+        }
+        return AUTH_MAP.get(serviceMode);
     }
 }


### PR DESCRIPTION
#25 

- Make private members final static
- Instantiate authGenerators only upon request
- Check dataType is valid before creating or retrieving auth.