### PR TITLE
Increase timeout for Karma to receive activity from Chrome

### DIFF
--- a/client/karma.conf.js
+++ b/client/karma.conf.js
@@ -39,7 +39,9 @@ module.exports = function (config) {
     mime: {
       'text/x-typescript': ['ts','tsx']
     },
-    browserNoActivityTimeout: 100, // TODO: increase this
+    // The default timeout, 10000, was sometimes causing Karma to time out with:
+    // "Disconnected (1 times), because no message in 10000 ms."
+    browserNoActivityTimeout: 60000,
     coverageIstanbulReporter: {
       reports: [ 'html', 'lcovonly' ],
       fixWebpackSourcePaths: true

--- a/client/karma.conf.js
+++ b/client/karma.conf.js
@@ -39,6 +39,7 @@ module.exports = function (config) {
     mime: {
       'text/x-typescript': ['ts','tsx']
     },
+    browserNoActivityTimeout: 100, // TODO: increase this
     coverageIstanbulReporter: {
       reports: [ 'html', 'lcovonly' ],
       fixWebpackSourcePaths: true


### PR DESCRIPTION
Do not pull yet; testing on Travis with a lower timeout first to make sure it is the correct flag