### PR TITLE
Re add in ExportInformation

### DIFF
--- a/portability-spi-transfer/src/main/java/org/dataportabilityproject/spi/transfer/provider/Exporter.java
+++ b/portability-spi-transfer/src/main/java/org/dataportabilityproject/spi/transfer/provider/Exporter.java
@@ -15,7 +15,7 @@
  */
 package org.dataportabilityproject.spi.transfer.provider;
 
-import org.dataportabilityproject.spi.transfer.types.ContinuationData;
+import org.dataportabilityproject.spi.transfer.types.ExportInformation;
 import org.dataportabilityproject.types.transfer.auth.AuthData;
 import org.dataportabilityproject.types.transfer.models.DataModel;
 
@@ -33,7 +33,7 @@ public interface Exporter<A extends AuthData, T extends DataModel> {
      * Performs an export operation, starting from the data specified by the continuation.
      *
      * @param authData authentication data for the operation
-     * @param continuationData continuation data
+     * @param exportInformation info about what data to export see {@link ExportInformation} for more info
      */
-    ExportResult<T> export(A authData, ContinuationData continuationData); // REVIEW: The original throws IOException. Continue to use checked exceptions or use unchecked?
+    ExportResult<T> export(A authData, ExportInformation exportInformation); // REVIEW: The original throws IOException. Continue to use checked exceptions or use unchecked?
 }

--- a/portability-spi-transfer/src/main/java/org/dataportabilityproject/spi/transfer/types/ContinuationData.java
+++ b/portability-spi-transfer/src/main/java/org/dataportabilityproject/spi/transfer/types/ContinuationData.java
@@ -11,8 +11,6 @@ import org.dataportabilityproject.types.transfer.models.ContainerResource;
 
 /**
  * Specifies the starting point and context information for an export operation.
- *
- * REVIEW: This combines the original ContinuationInformation and ExportInformation
  */
 @JsonTypeName("org.dataportability:Continuation")
 public class ContinuationData extends EntityType {

--- a/portability-spi-transfer/src/main/java/org/dataportabilityproject/spi/transfer/types/ExportInformation.java
+++ b/portability-spi-transfer/src/main/java/org/dataportabilityproject/spi/transfer/types/ExportInformation.java
@@ -1,0 +1,46 @@
+package org.dataportabilityproject.spi.transfer.types;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import org.dataportabilityproject.types.transfer.EntityType;
+import org.dataportabilityproject.types.transfer.models.ContainerResource;
+
+/**
+ * Contains information about how to export data.
+ */
+@JsonTypeName("org.dataportability:ExportInformation")
+public class ExportInformation extends EntityType {
+  private final PaginationData paginationData;
+  private final ContainerResource containerResource;
+
+  /**
+   * Construct a new instance.
+   * @param paginationData data about how to fetch the next page of data of the given resource
+   *                       may be null to indicate the first page of data should be fetched
+   * @param containerResource the parent resource, the export call will export child items of this
+   *                          resource, may be null to indicate the root resource should be fetched
+   */
+  @JsonCreator
+  public ExportInformation(
+      PaginationData paginationData,
+      ContainerResource containerResource) {
+    this.paginationData = paginationData;
+    this.containerResource = containerResource;
+  }
+
+  /**
+   * Data about how to fetch the next page of data of the given resource may be null to
+   * indicate the first page of data should be fetched
+   */
+  public PaginationData getPaginationData() {
+    return paginationData;
+  }
+
+  /**
+   * the parent resource, the export call will export child items of this resource, may be null
+   * to indicate the root resource should be fetched
+   */
+  public ContainerResource getContainerResource() {
+    return containerResource;
+  }
+}

--- a/portability-types-transfer/src/main/java/org/dataportabilityproject/types/transfer/models/ContainerResource.java
+++ b/portability-types-transfer/src/main/java/org/dataportabilityproject/types/transfer/models/ContainerResource.java
@@ -1,12 +1,10 @@
 package org.dataportabilityproject.types.transfer.models;
 
-import org.dataportabilityproject.types.transfer.PortableType;
-
 /**
  * A resource that contains data items such as a photo album or song list.
  * <p>
  * Concrete subtypes must use {@link com.fasterxml.jackson.annotation.JsonTypeName} to specify a type descriminator used for deserialization.
  */
-public abstract class ContainerResource extends PortableType {
+public abstract class ContainerResource extends DataModel {
 
 }


### PR DESCRIPTION
Using ContinuationData as the input to the export call doesn't work because you then don't know which resource to apply the continuation data to.

So a call to export need to take 0 or 1 resources and 0 or 1 continuation tokens, which is now represented in ExportInformation