### PR TITLE
Use a key query in Datastore for polling

### DIFF
--- a/extensions/cloud/portability-cloud-google/src/main/java/org/dataportabilityproject/cloud/google/GoogleCloudDatastore.java
+++ b/extensions/cloud/portability-cloud-google/src/main/java/org/dataportabilityproject/cloud/google/GoogleCloudDatastore.java
@@ -120,18 +120,18 @@ public final class GoogleCloudDatastore implements JobStore {
    */
   @Override
   public String findFirst(JobState jobState) {
-    Query<Entity> query = Query.newEntityQueryBuilder()
+    Query<Key> query = Query.newKeyQueryBuilder()
         .setKind(KIND)
         .setFilter(PropertyFilter.eq(OldPortabilityJobConverter.JOB_STATE, jobState.name()))
         .setOrderBy(OrderBy.asc("created"))
         .setLimit(1)
         .build();
-    QueryResults<Entity> results = datastore.run(query);
+    QueryResults<Key> results = datastore.run(query);
     if (!results.hasNext()) {
       return null;
     }
-    Entity entity = results.next();
-    return (String) entity.getValue(OldPortabilityJobConverter.ID_DATA_KEY).get();
+    Key key = results.next();
+    return key.getName();
   }
 
   /**


### PR DESCRIPTION
This returns the job ID from the key rather than the value (Entity).

This is necessary so we can remove job ID being stored as part of PortabilityJob in JobStore. This was one place that relied on job ID being stored as part of the job (e.g. Entity).

Tested locally with local Datastore emulator with encryptedFlow=true so we test the worker polling

More on Datastore key queries: https://cloud.google.com/datastore/docs/concepts/queries#keys-only_queries