### PR TITLE
Fix a couple deployment-related issues

### DIFF
--- a/bin/build_and_run_jar.sh
+++ b/bin/build_and_run_jar.sh
@@ -131,7 +131,7 @@ fi
 echo -e "\nCompiling and packaging...\n"
 
 gradle wrapper
-./gradlew build
+./gradlew clean build
 
 # TODO: Exit in case of error compiling
 

--- a/config/gcp/build_and_upload_docker_image.sh
+++ b/config/gcp/build_and_upload_docker_image.sh
@@ -128,7 +128,7 @@ fi
 # once uploaded to GCP, pull the image and 'docker inspect' it
 cat >Dockerfile <<EOF
 FROM gcr.io/google-appengine/openjdk:8
-COPY $SRC_DIR/target/$SRC_DIR-1.0-SNAPSHOT.jar /$BINARY.jar
+COPY $SRC_DIR/build/libs/$SRC_DIR-1.0-SNAPSHOT.jar /$BINARY.jar
 $LOCAL_DEBUG_SETTINGS
 ENTRYPOINT ["java", $OPTIONAL_DEBUG_FLAG "-jar", "/$BINARY.jar"]
 EXPOSE 8080/tcp


### PR DESCRIPTION
1. Use a clean build when building a jar
2. Copy the correct jar into our Docker images. We were still copying the old Maven jars.