### PR TITLE
Remove jobId from PortabilityJob, and make it type UUID instead of String

### DIFF
--- a/extensions/cloud/portability-cloud-microsoft/src/main/java/org/dataportabilityproject/cloud/microsoft/cosmos/CosmosStore.java
+++ b/extensions/cloud/portability-cloud-microsoft/src/main/java/org/dataportabilityproject/cloud/microsoft/cosmos/CosmosStore.java
@@ -21,6 +21,7 @@ import com.datastax.driver.core.Row;
 import com.datastax.driver.core.Session;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Preconditions;
 import org.dataportabilityproject.spi.cloud.storage.JobStore;
 import org.dataportabilityproject.spi.cloud.types.LegacyPortabilityJob;
 import org.dataportabilityproject.spi.cloud.types.PortabilityJob;
@@ -34,18 +35,27 @@ import static org.dataportabilityproject.cloud.microsoft.cosmos.MicrosoftCloudCo
 import static org.dataportabilityproject.cloud.microsoft.cosmos.MicrosoftCloudConstants.JOB_TABLE;
 
 /**
- * A {@link JobStore} backed by Cosmos DB. This implementation uses the DataStax Cassandra driver to communicate with Cosmos DB.
+ * A {@link JobStore} backed by Cosmos DB. This implementation uses the DataStax Cassandra driver to
+ * communicate with Cosmos DB.
  */
 public class CosmosStore implements JobStore {
-    static final String JOB_INSERT = String.format("INSERT INTO  %s (job_id, job_data) VALUES (?,?)", JOB_TABLE);
-    static final String JOB_QUERY = String.format("SELECT * FROM %s WHERE job_id = ?", JOB_TABLE);
-    static final String JOB_DELETE = String.format("DELETE FROM %s WHERE job_id = ?", JOB_TABLE);
-    static final String JOB_UPDATE = String.format("UPDATE %s SET job_data = ? WHERE job_id = ?", JOB_TABLE);
+    static final String JOB_INSERT =
+        String.format("INSERT INTO  %s (job_id, job_data) VALUES (?,?)", JOB_TABLE);
+    static final String JOB_QUERY =
+        String.format("SELECT * FROM %s WHERE job_id = ?", JOB_TABLE);
+    static final String JOB_DELETE =
+        String.format("DELETE FROM %s WHERE job_id = ?", JOB_TABLE);
+    static final String JOB_UPDATE =
+        String.format("UPDATE %s SET job_data = ? WHERE job_id = ?", JOB_TABLE);
 
-    static final String DATA_INSERT = String.format("INSERT INTO  %s (data_id, data_model) VALUES (?,?)", DATA_TABLE);
-    static final String DATA_QUERY = String.format("SELECT * FROM %s WHERE data_id = ?", DATA_TABLE);
-    static final String DATA_DELETE = String.format("DELETE FROM %s WHERE data_id = ?", DATA_TABLE);
-    static final String DATA_UPDATE = String.format("UPDATE %s SET data_model = ? WHERE data_id = ?", DATA_TABLE);
+    static final String DATA_INSERT =
+        String.format("INSERT INTO  %s (data_id, data_model) VALUES (?,?)", DATA_TABLE);
+    static final String DATA_QUERY =
+        String.format("SELECT * FROM %s WHERE data_id = ?", DATA_TABLE);
+    static final String DATA_DELETE =
+        String.format("DELETE FROM %s WHERE data_id = ?", DATA_TABLE);
+    static final String DATA_UPDATE =
+        String.format("UPDATE %s SET data_model = ? WHERE data_id = ?", DATA_TABLE);
 
     private final Session session;
     private final ObjectMapper mapper;
@@ -62,87 +72,81 @@ public class CosmosStore implements JobStore {
     }
 
     @Override
-    public void createJob(PortabilityJob job) {
-        if (job.getId() != null) {
-            throw new IllegalStateException("Job already created: " + job.getId());
-        }
-        UUID uuid = UUID.randomUUID();
-        job.setId(uuid.toString());
-        create(uuid, job, JOB_INSERT);
+    public void createJob(UUID jobId, PortabilityJob job) {
+        create(jobId, job, JOB_INSERT);
     }
 
     @Override
-    public void updateJob(PortabilityJob job) {
-        if (job.getId() == null) {
-            throw new IllegalStateException("Job not persisted: " + job.getId());
-        }
-        update(job.getId(), job, JOB_UPDATE);
+    public void updateJob(UUID jobId, PortabilityJob job) {
+        Preconditions.checkNotNull(jobId, "Job not persisted");
+        update(jobId, job, JOB_UPDATE);
     }
 
     @Override
-    public PortabilityJob findJob(String id) {
+    public PortabilityJob findJob(UUID id) {
         return findData(PortabilityJob.class, id, JOB_QUERY, "job_data");
     }
 
     @Override
-    public void remove(String id) {
+    public void remove(UUID id) {
         remove(id, JOB_DELETE);
     }
 
     @Override
-    public <T extends DataModel> void create(String jobId, T model) {
-        create(UUID.fromString(jobId), model, DATA_INSERT);
+    public <T extends DataModel> void create(UUID jobId, T model) {
+        create(jobId, model, DATA_INSERT);
     }
 
     @Override
-    public <T extends DataModel> void update(String jobId, T model) {
+    public <T extends DataModel> void update(UUID jobId, T model) {
         update(jobId, model, DATA_UPDATE);
     }
 
     @Override
-    public <T extends DataModel> T findData(Class<T> type, String id) {
+    public <T extends DataModel> T findData(Class<T> type, UUID id) {
         return findData(type, id, DATA_QUERY, "data_model");
     }
 
     @Override
-    public void removeData(String id) {
+    public void removeData(UUID id) {
         remove(id, DATA_DELETE);
     }
 
     @Override
-    public void create(String jobId, String key, InputStream stream) {
+    public void create(UUID jobId, String key, InputStream stream) {
         // TODO implement with Azure Blob Storage
         throw new UnsupportedOperationException("Not yet implemented");
     }
 
     @Override
-    public InputStream getStream(String jobId, String key) {
+    public InputStream getStream(UUID jobId, String key) {
         // TODO implement with Azure Blob Storage
         throw new UnsupportedOperationException("Not yet implemented");
     }
 
     @Override
-    public void create(LegacyPortabilityJob job) throws IOException {
+    public void create(UUID jobId, LegacyPortabilityJob job) throws IOException {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void update(LegacyPortabilityJob job, LegacyPortabilityJob.JobState previousState) throws IOException {
+    public void update(UUID jobId, LegacyPortabilityJob job,
+        LegacyPortabilityJob.JobState previousState) throws IOException {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public LegacyPortabilityJob find(String jobId) {
+    public LegacyPortabilityJob find(UUID jobId) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public String findFirst(LegacyPortabilityJob.JobState jobState) {
+    public UUID findFirst(LegacyPortabilityJob.JobState jobState) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public LegacyPortabilityJob find(String jobId, LegacyPortabilityJob.JobState jobState) {
+    public LegacyPortabilityJob find(UUID jobId, LegacyPortabilityJob.JobState jobState) {
         throw new UnsupportedOperationException();
     }
 
@@ -158,22 +162,22 @@ public class CosmosStore implements JobStore {
         }
     }
 
-    private void update(String id, Object instance, String query) {
+    private void update(UUID id, Object instance, String query) {
         PreparedStatement statement = session.prepare(query);
         BoundStatement boundStatement = new BoundStatement(statement);
         try {
             boundStatement.setString(0, mapper.writeValueAsString(instance));
-            boundStatement.setUUID(1, UUID.fromString(id));
+            boundStatement.setUUID(1, id);
             session.execute(boundStatement);
         } catch (JsonProcessingException e) {
             throw new MicrosoftStorageException("Error deleting data: " + id, e);
         }
     }
 
-    private <T> T findData(Class<T> type, String id, String query, String column) {
+    private <T> T findData(Class<T> type, UUID id, String query, String column) {
         PreparedStatement statement = session.prepare(query);
         BoundStatement boundStatement = new BoundStatement(statement);
-        boundStatement.bind(UUID.fromString(id));
+        boundStatement.bind(id);
 
         Row row = session.execute(boundStatement).one();
         String serialized = row.getString(column);
@@ -184,12 +188,10 @@ public class CosmosStore implements JobStore {
         }
     }
 
-    private void remove(String id, String query) {
+    private void remove(UUID id, String query) {
         PreparedStatement statement = session.prepare(query);
         BoundStatement boundStatement = new BoundStatement(statement);
-        boundStatement.setUUID(0, UUID.fromString(id));
+        boundStatement.setUUID(0, id);
         session.execute(boundStatement);
     }
-
-
 }

--- a/extensions/cloud/portability-cloud-microsoft/src/test/java/org/dataportabilityproject/cloud/microsoft/cosmos/CosmosStoreTest.java
+++ b/extensions/cloud/portability-cloud-microsoft/src/test/java/org/dataportabilityproject/cloud/microsoft/cosmos/CosmosStoreTest.java
@@ -15,7 +15,18 @@
  */
 package org.dataportabilityproject.cloud.microsoft.cosmos;
 
+import static org.dataportabilityproject.cloud.microsoft.cosmos.CosmosStore.JOB_DELETE;
+import static org.dataportabilityproject.cloud.microsoft.cosmos.CosmosStore.JOB_INSERT;
+import static org.dataportabilityproject.cloud.microsoft.cosmos.CosmosStore.JOB_QUERY;
+import static org.dataportabilityproject.cloud.microsoft.cosmos.CosmosStore.JOB_UPDATE;
+import static org.dataportabilityproject.spi.cloud.types.PortabilityJob.State.COMPLETE;
+import static org.scassandra.cql.PrimitiveType.UUID;
+import static org.scassandra.cql.PrimitiveType.VARCHAR;
+import static org.scassandra.matchers.Matchers.preparedStatementRecorded;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Collections;
+import java.util.Map;
 import org.dataportabilityproject.spi.cloud.types.PortabilityJob;
 import org.junit.Assert;
 import org.junit.Before;
@@ -26,18 +37,6 @@ import org.scassandra.ScassandraFactory;
 import org.scassandra.http.client.PreparedStatementExecution;
 import org.scassandra.http.client.PrimingRequest;
 import org.scassandra.http.client.types.ColumnMetadata;
-
-import java.util.Collections;
-import java.util.Map;
-
-import static org.dataportabilityproject.cloud.microsoft.cosmos.CosmosStore.JOB_DELETE;
-import static org.dataportabilityproject.cloud.microsoft.cosmos.CosmosStore.JOB_INSERT;
-import static org.dataportabilityproject.cloud.microsoft.cosmos.CosmosStore.JOB_QUERY;
-import static org.dataportabilityproject.cloud.microsoft.cosmos.CosmosStore.JOB_UPDATE;
-import static org.dataportabilityproject.spi.cloud.types.PortabilityJob.State.COMPLETE;
-import static org.scassandra.cql.PrimitiveType.UUID;
-import static org.scassandra.cql.PrimitiveType.VARCHAR;
-import static org.scassandra.matchers.Matchers.preparedStatementRecorded;
 
 /**
  * Verifies the CosmosStore implementation against a mock Cassandra instance.
@@ -51,24 +50,26 @@ public class CosmosStoreTest {
     public void verifyCreateAndFind() throws Exception {
         PrimingRequest.Then.ThenBuilder thenInsert = PrimingRequest.then();
         thenInsert.withVariableTypes(UUID, VARCHAR);
-        PrimingRequest createRequest = PrimingRequest.preparedStatementBuilder().withQuery(JOB_INSERT).withThen(thenInsert).build();
+        PrimingRequest createRequest = PrimingRequest.preparedStatementBuilder()
+            .withQuery(JOB_INSERT).withThen(thenInsert).build();
 
         cassandra.primingClient().prime(createRequest);
 
         PortabilityJob primeJob = new PortabilityJob();
-        primeJob.setId(java.util.UUID.randomUUID().toString());
+        java.util.UUID jobId = java.util.UUID.randomUUID();
         Map row = Collections.singletonMap("job_data", new ObjectMapper().writeValueAsString(primeJob));
 
         PrimingRequest.Then.ThenBuilder thenQuery = PrimingRequest.then();
         PrimingRequest findRequest = PrimingRequest.preparedStatementBuilder()
                 .withQuery(JOB_QUERY)
-                .withThen(thenQuery.withVariableTypes(UUID).withColumnTypes(ColumnMetadata.column("job_id", UUID)).withRows(row))
-                .build();
+                .withThen(thenQuery.withVariableTypes(UUID)
+                    .withColumnTypes(ColumnMetadata.column("job_id", UUID)).withRows(row)).build();
 
         cassandra.primingClient().prime(findRequest);
 
         PrimingRequest.Then.ThenBuilder thenUpdate = PrimingRequest.then();
-        thenUpdate.withVariableTypes(VARCHAR, UUID).withColumnTypes(ColumnMetadata.column("job_data", VARCHAR), ColumnMetadata.column("job_id", UUID));
+        thenUpdate.withVariableTypes(VARCHAR, UUID).withColumnTypes(
+            ColumnMetadata.column("job_data", VARCHAR), ColumnMetadata.column("job_id", UUID));
         PrimingRequest updateRequest = PrimingRequest.preparedStatementBuilder()
                 .withQuery(JOB_UPDATE)
                 .withThen(thenUpdate)
@@ -78,25 +79,26 @@ public class CosmosStoreTest {
 
         PrimingRequest.Then.ThenBuilder thenRemove = PrimingRequest.then();
         thenRemove.withVariableTypes(UUID);
-        PrimingRequest removeRequest = PrimingRequest.preparedStatementBuilder().withQuery(JOB_DELETE).withThen(thenRemove).build();
+        PrimingRequest removeRequest = PrimingRequest.preparedStatementBuilder()
+            .withQuery(JOB_DELETE).withThen(thenRemove).build();
         cassandra.primingClient().prime(removeRequest);
 
         PortabilityJob createJob = new PortabilityJob();
-        cosmosStore.createJob(createJob);
+        cosmosStore.createJob(jobId, createJob);
 
-        PortabilityJob copy = cosmosStore.findJob(createJob.getId());
+        PortabilityJob copy = cosmosStore.findJob(jobId);
         copy.setState(COMPLETE);
-        cosmosStore.updateJob(copy);
+        cosmosStore.updateJob(jobId, copy);
 
-        cosmosStore.remove(copy.getId());
+        cosmosStore.remove(jobId);
 
         PreparedStatementExecution expectedStatement = PreparedStatementExecution.builder()
                 .withPreparedStatementText(JOB_DELETE)
                 .withConsistency("LOCAL_ONE")
-                .withVariables(primeJob.getId())
                 .build();
 
-        Assert.assertThat(cassandra.activityClient().retrievePreparedStatementExecutions(), preparedStatementRecorded(expectedStatement));
+        Assert.assertThat(cassandra.activityClient().retrievePreparedStatementExecutions(),
+            preparedStatementRecorded(expectedStatement));
     }
 
     @Before

--- a/portability-api/src/main/java/org/dataportabilityproject/webapp/CryptoHelper.java
+++ b/portability-api/src/main/java/org/dataportabilityproject/webapp/CryptoHelper.java
@@ -23,6 +23,7 @@ import com.google.gson.Gson;
 import com.google.inject.Inject;
 import com.sun.net.httpserver.Headers;
 import java.net.HttpCookie;
+import java.util.UUID;
 import javax.crypto.SecretKey;
 import org.dataportabilityproject.cloud.interfaces.CloudFactory;
 import org.dataportabilityproject.job.Crypter;
@@ -67,7 +68,7 @@ class CryptoHelper {
    * Encrypts the given {@code authData} with the session-based {@link SecretKey} and stores it as a
    * cookie in the provided headers.
    */
-  void encryptAndSetCookie(Headers headers, String jobId, ServiceMode serviceMode,
+  void encryptAndSetCookie(Headers headers, UUID jobId, ServiceMode serviceMode,
       AuthData authData) {
     SecretKey sessionKey = getSessionKey(jobId);
     String encrypted = encrypt(sessionKey, authData);
@@ -80,7 +81,7 @@ class CryptoHelper {
     headers.add(HEADER_SET_COOKIE, cookie.toString() + PortabilityApiUtils.COOKIE_ATTRIBUTES);
   }
 
-  private SecretKey getSessionKey(String jobId) {
+  private SecretKey getSessionKey(UUID jobId) {
     LegacyPortabilityJob job = store.find(jobId);
     Preconditions.checkState(job != null && job.jobState() == JobState.PENDING_AUTH_DATA);
     String encodedSessionKey = job.sessionKey();

--- a/portability-api/src/main/java/org/dataportabilityproject/webapp/DataTransferHandler.java
+++ b/portability-api/src/main/java/org/dataportabilityproject/webapp/DataTransferHandler.java
@@ -127,7 +127,7 @@ final class DataTransferHandler implements HttpHandler {
       createJob(jobId, dataType, exportService, importService);
 
       // Set new cookie
-      HttpCookie cookie = new HttpCookie(JsonKeys.ID_COOKIE_KEY, JobUtils.encodeId(jobId));
+      HttpCookie cookie = new HttpCookie(JsonKeys.ID_COOKIE_KEY, JobUtils.encodeJobId(jobId));
       exchange.getResponseHeaders()
           .add(HEADER_SET_COOKIE, cookie.toString() + PortabilityApiUtils.COOKIE_ATTRIBUTES);
 

--- a/portability-api/src/main/java/org/dataportabilityproject/webapp/Oauth2CallbackHandler.java
+++ b/portability-api/src/main/java/org/dataportabilityproject/webapp/Oauth2CallbackHandler.java
@@ -28,6 +28,7 @@ import com.sun.net.httpserver.HttpHandler;
 import java.io.IOException;
 import java.net.HttpCookie;
 import java.util.Map;
+import java.util.UUID;
 import org.dataportabilityproject.ServiceProviderRegistry;
 import org.dataportabilityproject.cloud.interfaces.CloudFactory;
 import org.dataportabilityproject.job.JobUtils;
@@ -112,14 +113,13 @@ final class Oauth2CallbackHandler implements HttpHandler {
               encodedIdCookie != null && !Strings.isNullOrEmpty(encodedIdCookie.getValue()),
               "Encoded Id cookie required");
 
-      String jobId = JobUtils.decodeId(encodedIdCookie.getValue());
-      String state = JobUtils.decodeId(authResponse.getState());
+      UUID jobId = JobUtils.decodeId(encodedIdCookie.getValue());
+      UUID state = JobUtils.decodeId(authResponse.getState());
 
       // TODO: Remove sanity check
       Preconditions
           .checkState(state.equals(jobId), "Job id in cookie [%s] and request [%s] should match",
               jobId, state);
-
 
       LegacyPortabilityJob job = commonSettings.getEncryptedFlow()
           ? store.find(jobId, JobState.PENDING_AUTH_DATA) : store.find(jobId);
@@ -154,11 +154,11 @@ final class Oauth2CallbackHandler implements HttpHandler {
       if (!commonSettings.getEncryptedFlow()) {
         // Update the job
         LegacyPortabilityJob updatedJob = JobUtils.setAuthData(job, authData, serviceMode);
-        store.update(updatedJob, null);
+        store.update(jobId, updatedJob, null);
       } else {
         // Set new cookie
         cryptoHelper
-            .encryptAndSetCookie(exchange.getResponseHeaders(), job.id(), serviceMode, authData);
+            .encryptAndSetCookie(exchange.getResponseHeaders(), jobId, serviceMode, authData);
       }
 
       redirect =

--- a/portability-api/src/main/java/org/dataportabilityproject/webapp/Oauth2CallbackHandler.java
+++ b/portability-api/src/main/java/org/dataportabilityproject/webapp/Oauth2CallbackHandler.java
@@ -113,13 +113,12 @@ final class Oauth2CallbackHandler implements HttpHandler {
               encodedIdCookie != null && !Strings.isNullOrEmpty(encodedIdCookie.getValue()),
               "Encoded Id cookie required");
 
-      UUID jobId = JobUtils.decodeId(encodedIdCookie.getValue());
-      UUID state = JobUtils.decodeId(authResponse.getState());
+      UUID jobId = JobUtils.decodeJobId(encodedIdCookie.getValue());
+      String state = JobUtils.decodeBase64(authResponse.getState());
 
       // TODO: Remove sanity check
-      Preconditions
-          .checkState(state.equals(jobId), "Job id in cookie [%s] and request [%s] should match",
-              jobId, state);
+      Preconditions.checkState(state.equals(jobId.toString()),
+          "Job id in cookie [%s] and request [%s] should match", jobId, state);
 
       LegacyPortabilityJob job = commonSettings.getEncryptedFlow()
           ? store.find(jobId, JobState.PENDING_AUTH_DATA) : store.find(jobId);

--- a/portability-api/src/main/java/org/dataportabilityproject/webapp/OauthCallbackHandler.java
+++ b/portability-api/src/main/java/org/dataportabilityproject/webapp/OauthCallbackHandler.java
@@ -112,7 +112,7 @@ final class OauthCallbackHandler implements HttpHandler {
       // Valid job must be present
       Preconditions
           .checkArgument(!Strings.isNullOrEmpty(encodedIdCookie), "Encoded Id cookie required");
-      UUID jobId = JobUtils.decodeId(encodedIdCookie);
+      UUID jobId = JobUtils.decodeJobId(encodedIdCookie);
 
       LegacyPortabilityJob job = commonSettings.getEncryptedFlow()
           ? store.find(jobId, JobState.PENDING_AUTH_DATA) : store.find(jobId);

--- a/portability-api/src/main/java/org/dataportabilityproject/webapp/OauthCallbackHandler.java
+++ b/portability-api/src/main/java/org/dataportabilityproject/webapp/OauthCallbackHandler.java
@@ -26,6 +26,7 @@ import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
 import java.io.IOException;
 import java.util.Map;
+import java.util.UUID;
 import org.dataportabilityproject.ServiceProviderRegistry;
 import org.dataportabilityproject.cloud.interfaces.CloudFactory;
 import org.dataportabilityproject.job.JobUtils;
@@ -111,7 +112,7 @@ final class OauthCallbackHandler implements HttpHandler {
       // Valid job must be present
       Preconditions
           .checkArgument(!Strings.isNullOrEmpty(encodedIdCookie), "Encoded Id cookie required");
-      String jobId = JobUtils.decodeId(encodedIdCookie);
+      UUID jobId = JobUtils.decodeId(encodedIdCookie);
 
       LegacyPortabilityJob job = commonSettings.getEncryptedFlow()
           ? store.find(jobId, JobState.PENDING_AUTH_DATA) : store.find(jobId);
@@ -147,11 +148,11 @@ final class OauthCallbackHandler implements HttpHandler {
       if (!commonSettings.getEncryptedFlow()) {
         // Update the job
         LegacyPortabilityJob updatedJob = JobUtils.setAuthData(job, authData, serviceMode);
-        store.update(updatedJob, null);
+        store.update(jobId, updatedJob, null);
       } else {
         // Set new cookie
         cryptoHelper
-            .encryptAndSetCookie(exchange.getResponseHeaders(), job.id(), serviceMode, authData);
+            .encryptAndSetCookie(exchange.getResponseHeaders(), jobId, serviceMode, authData);
       }
 
       redirect =

--- a/portability-api/src/main/java/org/dataportabilityproject/webapp/PortabilityApiModule.java
+++ b/portability-api/src/main/java/org/dataportabilityproject/webapp/PortabilityApiModule.java
@@ -20,7 +20,7 @@ import com.google.inject.AbstractModule;
 import com.google.inject.multibindings.MapBinder;
 import com.sun.net.httpserver.HttpHandler;
 import org.dataportabilityproject.PortabilityCoreModule;
-import org.dataportabilityproject.job.PortabilityJobFactory;
+import org.dataportabilityproject.job.IdProvider;
 import org.dataportabilityproject.job.UUIDProvider;
 
 public class PortabilityApiModule extends AbstractModule {
@@ -28,7 +28,7 @@ public class PortabilityApiModule extends AbstractModule {
   @Override
   protected void configure() {
     install(new PortabilityCoreModule());
-    bind(PortabilityJobFactory.class).toInstance(new PortabilityJobFactory(new UUIDProvider()));
+    bind(IdProvider.class).toInstance(new UUIDProvider());
 
     MapBinder<String, HttpHandler> mapbinder
         = MapBinder.newMapBinder(binder(), String.class, HttpHandler.class);

--- a/portability-api/src/main/java/org/dataportabilityproject/webapp/PortabilityApiUtils.java
+++ b/portability-api/src/main/java/org/dataportabilityproject/webapp/PortabilityApiUtils.java
@@ -30,6 +30,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.UUID;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import org.apache.http.NameValuePair;
@@ -182,33 +183,38 @@ public class PortabilityApiUtils {
    * Validates that the JobId in the request matches the jobId in the xsrf header and contains
    * Does not validate that the job id itself is valid. Returns JobID.
    */
-  public static String validateJobId(Headers requestHeaders, TokenManager tokenManager) {
+  public static UUID validateJobId(Headers requestHeaders, TokenManager tokenManager) {
     String encodedIdCookie = PortabilityApiUtils
         .getCookie(requestHeaders, JsonKeys.ID_COOKIE_KEY);
     Preconditions
         .checkArgument(!Strings.isNullOrEmpty(encodedIdCookie), "Encoded Id cookie required");
 
     // Valid job must be present
-    String jobId = JobUtils.decodeId(encodedIdCookie);
+    UUID jobId = JobUtils.decodeId(encodedIdCookie);
 
     // Validate XSRF token is present in request header and in the token.
     String tokenHeader = parseXsrfTokenHeader(requestHeaders);
-    String tokenCookie = PortabilityApiUtils
-        .getCookie(requestHeaders, JsonKeys.XSRF_TOKEN);
+    String tokenCookie = PortabilityApiUtils.getCookie(requestHeaders, JsonKeys.XSRF_TOKEN);
 
     // Both header and token should be present
-    Preconditions.checkArgument(!Strings.isNullOrEmpty(tokenHeader), "xsrf token header must be present");
-    Preconditions.checkArgument(!Strings.isNullOrEmpty(tokenCookie), "xsrf token cookie must be present");
+    Preconditions.checkArgument(!Strings.isNullOrEmpty(tokenHeader),
+        "xsrf token header must be present");
+    Preconditions.checkArgument(!Strings.isNullOrEmpty(tokenCookie),
+        "xsrf token cookie must be present");
 
     // The token present in the header should be the same as the token present in the cookie.
-    Preconditions.checkArgument(tokenCookie.equals(tokenHeader), "xsrf token header and cookie must match");
+    Preconditions.checkArgument(tokenCookie.equals(tokenHeader),
+        "xsrf token header and cookie must match");
 
     // Verify that the token is actually valid in the tokenManager
-    Preconditions.checkArgument(tokenManager.verifyToken(tokenHeader), "xsrf token provided is invalid");
+    Preconditions.checkArgument(tokenManager.verifyToken(tokenHeader),
+        "xsrf token provided is invalid");
 
-    // finally make sure the jobId present in the token is also equal to the jobId present in the cookie
-    String jobIdFromToken = tokenManager.getData(tokenHeader);
-    Preconditions.checkArgument(jobId.equals(jobIdFromToken), "encoded job id and job id token must match");
+    // finally make sure the jobId present in the token is also equal to the jobId present in the
+    // cookie
+    UUID jobIdFromToken = tokenManager.getData(tokenHeader);
+    Preconditions.checkArgument(jobId.equals(jobIdFromToken),
+        "encoded job id and job id token must match");
     return jobId;
   }
 

--- a/portability-api/src/main/java/org/dataportabilityproject/webapp/PortabilityApiUtils.java
+++ b/portability-api/src/main/java/org/dataportabilityproject/webapp/PortabilityApiUtils.java
@@ -190,7 +190,7 @@ public class PortabilityApiUtils {
         .checkArgument(!Strings.isNullOrEmpty(encodedIdCookie), "Encoded Id cookie required");
 
     // Valid job must be present
-    UUID jobId = JobUtils.decodeId(encodedIdCookie);
+    UUID jobId = JobUtils.decodeJobId(encodedIdCookie);
 
     // Validate XSRF token is present in request header and in the token.
     String tokenHeader = parseXsrfTokenHeader(requestHeaders);

--- a/portability-api/src/main/java/org/dataportabilityproject/webapp/PortabilityApiUtils.java
+++ b/portability-api/src/main/java/org/dataportabilityproject/webapp/PortabilityApiUtils.java
@@ -212,7 +212,7 @@ public class PortabilityApiUtils {
 
     // finally make sure the jobId present in the token is also equal to the jobId present in the
     // cookie
-    UUID jobIdFromToken = tokenManager.getData(tokenHeader);
+    UUID jobIdFromToken = tokenManager.getJobIdFromToken(tokenHeader);
     Preconditions.checkArgument(jobId.equals(jobIdFromToken),
         "encoded job id and job id token must match");
     return jobId;

--- a/portability-api/src/main/java/org/dataportabilityproject/webapp/SetupHandler.java
+++ b/portability-api/src/main/java/org/dataportabilityproject/webapp/SetupHandler.java
@@ -90,7 +90,7 @@ abstract class SetupHandler implements HttpHandler {
           .checkArgument(!Strings.isNullOrEmpty(encodedIdCookie), "Encoded Id cookie required");
 
       // Valid job must be present
-      UUID jobId = JobUtils.decodeId(encodedIdCookie);
+      UUID jobId = JobUtils.decodeJobId(encodedIdCookie);
       LegacyPortabilityJob job = commonSettings.getEncryptedFlow()
           ? store.find(jobId, JobState.PENDING_AUTH_DATA) : store.find(jobId);
       Preconditions.checkNotNull(job, "existing job not found for jobId: %s", jobId);

--- a/portability-api/src/main/java/org/dataportabilityproject/webapp/SetupHandler.java
+++ b/portability-api/src/main/java/org/dataportabilityproject/webapp/SetupHandler.java
@@ -29,6 +29,7 @@ import com.sun.net.httpserver.HttpHandler;
 import java.io.IOException;
 import java.net.HttpCookie;
 import java.nio.charset.StandardCharsets;
+import java.util.UUID;
 import org.dataportabilityproject.ServiceProviderRegistry;
 import org.dataportabilityproject.cloud.interfaces.CloudFactory;
 import org.dataportabilityproject.job.JobUtils;
@@ -89,7 +90,7 @@ abstract class SetupHandler implements HttpHandler {
           .checkArgument(!Strings.isNullOrEmpty(encodedIdCookie), "Encoded Id cookie required");
 
       // Valid job must be present
-      String jobId = JobUtils.decodeId(encodedIdCookie);
+      UUID jobId = JobUtils.decodeId(encodedIdCookie);
       LegacyPortabilityJob job = commonSettings.getEncryptedFlow()
           ? store.find(jobId, JobState.PENDING_AUTH_DATA) : store.find(jobId);
       Preconditions.checkNotNull(job, "existing job not found for jobId: %s", jobId);
@@ -109,7 +110,7 @@ abstract class SetupHandler implements HttpHandler {
       DataTransferResponse response;
 
       if (mode == IMPORT) {
-        response = handleImportSetup(exchange.getRequestHeaders(), job);
+        response = handleImportSetup(exchange.getRequestHeaders(), job, jobId);
       } else {
         response = handleCopySetup(exchange.getRequestHeaders(), job);
         // Valid job is present, generate an XSRF token to pass back via cookie
@@ -130,8 +131,8 @@ abstract class SetupHandler implements HttpHandler {
     }
   }
 
-  private DataTransferResponse handleImportSetup(Headers headers, LegacyPortabilityJob job)
-      throws IOException {
+  private DataTransferResponse handleImportSetup(Headers headers, LegacyPortabilityJob job,
+      UUID jobId) throws IOException {
     if (!commonSettings.getEncryptedFlow()) {
       Preconditions.checkState(job.importAuthData() == null, "Import AuthData should not exist");
     } else {
@@ -144,8 +145,8 @@ abstract class SetupHandler implements HttpHandler {
     OnlineAuthDataGenerator generator = serviceProviderRegistry
         .getOnlineAuth(job.importService(), JobUtils.getDataType(job.dataType()),
             ServiceMode.IMPORT);
-    AuthFlowInitiator authFlowInitiator = generator
-        .generateAuthUrl(PortabilityApiFlags.baseApiUrl(), JobUtils.encodeId(job));
+    AuthFlowInitiator authFlowInitiator =
+        generator.generateAuthUrl(PortabilityApiFlags.baseApiUrl(), jobId);
 
     // This is done in DataTransferHandler as well for export services
     if (authFlowInitiator.initialAuthData() != null) {
@@ -155,7 +156,7 @@ abstract class SetupHandler implements HttpHandler {
           .setInitialAuthData(job, authFlowInitiator.initialAuthData(), ServiceMode.IMPORT);
       JobState expectedPreviousState =
           commonSettings.getEncryptedFlow() ? JobState.PENDING_AUTH_DATA : null;
-      store.update(job, expectedPreviousState);
+      store.update(jobId, job, expectedPreviousState);
     }
     return new DataTransferResponse(job.exportService(), job.importService(), job.dataType(),
         Status.INPROCESS, authFlowInitiator.authUrl()); // Redirect to auth page of import service

--- a/portability-api/src/main/java/org/dataportabilityproject/webapp/SimpleLoginSubmitHandler.java
+++ b/portability-api/src/main/java/org/dataportabilityproject/webapp/SimpleLoginSubmitHandler.java
@@ -25,6 +25,7 @@ import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.UUID;
 import org.dataportabilityproject.ServiceProviderRegistry;
 import org.dataportabilityproject.cloud.interfaces.CloudFactory;
 import org.dataportabilityproject.job.JobUtils;
@@ -95,7 +96,7 @@ final class SimpleLoginSubmitHandler implements HttpHandler {
           .getCookie(exchange.getRequestHeaders(), JsonKeys.ID_COOKIE_KEY);
       Preconditions
           .checkArgument(!Strings.isNullOrEmpty(encodedIdCookie), "Encoded Id Cookie required");
-      String jobId = JobUtils.decodeId(encodedIdCookie);
+      UUID jobId = JobUtils.decodeId(encodedIdCookie);
 
       LegacyPortabilityJob job = commonSettings.getEncryptedFlow()
           ? store.find(jobId, JobState.PENDING_AUTH_DATA) : store.find(jobId);
@@ -131,16 +132,17 @@ final class SimpleLoginSubmitHandler implements HttpHandler {
       if (!commonSettings.getEncryptedFlow()) {
         // Update the job
         LegacyPortabilityJob updatedJob = JobUtils.setAuthData(job, authData, serviceMode);
-        store.update(updatedJob, null);
+        store.update(jobId, updatedJob, null);
       }
 
       if (commonSettings.getEncryptedFlow()) {
-        cryptoHelper.encryptAndSetCookie(exchange.getResponseHeaders(), job.id(), serviceMode, authData);
+        cryptoHelper.encryptAndSetCookie(exchange.getResponseHeaders(), jobId, serviceMode,
+            authData);
       }
 
-      response = new DataTransferResponse(job.exportService(), job.importService(), job.dataType(), Status.INPROCESS,
-          PortabilityApiFlags.baseUrl() + (serviceMode == ServiceMode.EXPORT
-              ? FrontendConstantUrls.next : FrontendConstantUrls.copy));
+      response = new DataTransferResponse(job.exportService(), job.importService(), job.dataType(),
+          Status.INPROCESS, PortabilityApiFlags.baseUrl() + (serviceMode == ServiceMode.EXPORT
+          ? FrontendConstantUrls.next : FrontendConstantUrls.copy));
 
     } catch (Exception e) {
       logger.debug("Exception occurred while trying to handle request: {}", e);

--- a/portability-api/src/main/java/org/dataportabilityproject/webapp/SimpleLoginSubmitHandler.java
+++ b/portability-api/src/main/java/org/dataportabilityproject/webapp/SimpleLoginSubmitHandler.java
@@ -96,7 +96,7 @@ final class SimpleLoginSubmitHandler implements HttpHandler {
           .getCookie(exchange.getRequestHeaders(), JsonKeys.ID_COOKIE_KEY);
       Preconditions
           .checkArgument(!Strings.isNullOrEmpty(encodedIdCookie), "Encoded Id Cookie required");
-      UUID jobId = JobUtils.decodeId(encodedIdCookie);
+      UUID jobId = JobUtils.decodeJobId(encodedIdCookie);
 
       LegacyPortabilityJob job = commonSettings.getEncryptedFlow()
           ? store.find(jobId, JobState.PENDING_AUTH_DATA) : store.find(jobId);

--- a/portability-api/src/test/java/org/dataportabilityproject/webapp/PortabilityApiUtilsTest.java
+++ b/portability-api/src/test/java/org/dataportabilityproject/webapp/PortabilityApiUtilsTest.java
@@ -6,13 +6,15 @@ import static org.apache.axis.transport.http.HTTPConstants.HEADER_COOKIE;
 import com.sun.net.httpserver.Headers;
 import java.net.HttpCookie;
 import java.util.Map;
+import java.util.UUID;
 import org.dataportabilityproject.job.JWTTokenManager;
 import org.dataportabilityproject.job.JobUtils;
 import org.dataportabilityproject.job.TokenManager;
-import org.dataportabilityproject.spi.cloud.types.LegacyPortabilityJob;
 import org.junit.Test;
 
 public class PortabilityApiUtilsTest {
+  private static final UUID JOB_ID = UUID.randomUUID();
+
   @Test
   public void parseCookieTest() {
     String cookieStr = "e_in=\"e_in_value\"; yummy_cookie=\"yummy_cookie_value\"";
@@ -31,13 +33,11 @@ public class PortabilityApiUtilsTest {
 
   @Test
   public void validateJobIdSuccessfulTest() {
-    TokenManager     tokenManager = new JWTTokenManager("TestSecret");
-
-    LegacyPortabilityJob testJob = LegacyPortabilityJob.builder().setId("123456").build();
+    TokenManager tokenManager = new JWTTokenManager("TestSecret");
 
     // create cookies
-    String encodedJobId = JobUtils.encodeId(testJob);;
-    String token = tokenManager.createNewToken(testJob.id());
+    String encodedJobId = JobUtils.encodeId(JOB_ID);;
+    String token = tokenManager.createNewToken(JOB_ID);
     String cookieStr = String
         .format("%s=%s;%s=%s", JsonKeys.ID_COOKIE_KEY, encodedJobId, JsonKeys.XSRF_TOKEN, token);
 
@@ -46,18 +46,21 @@ public class PortabilityApiUtilsTest {
     httpHeaders.add(HEADER_COOKIE, cookieStr);
     httpHeaders.add(JsonKeys.XSRF_HEADER, token);
 
-    String jobId = PortabilityApiUtils.validateJobId(httpHeaders, tokenManager);
-    assertThat(jobId).isEqualTo(testJob.id());
+    UUID jobId = PortabilityApiUtils.validateJobId(httpHeaders, tokenManager);
+    assertThat(jobId).isEqualTo(JOB_ID);
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void validateJobIdMismatchTest(){
-    TokenManager     tokenManager = new JWTTokenManager("TestSecret");
-    LegacyPortabilityJob testJob = LegacyPortabilityJob.builder().setId("123456").build();
+    TokenManager tokenManager = new JWTTokenManager("TestSecret");
 
     // create cookies - purposefully create a token thats not for the correct job ID.
-    String encodedJobId = JobUtils.encodeId(testJob);;
-    String token = tokenManager.createNewToken("789");
+    String encodedJobId = JobUtils.encodeId(JOB_ID);
+    UUID anotherId = UUID.randomUUID();
+    while (anotherId.equals(JOB_ID)) {
+      anotherId = UUID.randomUUID();
+    }
+    String token = tokenManager.createNewToken(anotherId);
 
     String cookieStr = String
         .format("%s=%s;%s=%s", JsonKeys.ID_COOKIE_KEY, encodedJobId, JsonKeys.XSRF_TOKEN, token);
@@ -68,20 +71,17 @@ public class PortabilityApiUtilsTest {
     httpHeaders.add(JsonKeys.XSRF_HEADER, token);
 
     // Should throw IllegalArgumentException due to mismatch of token and encoded job id.
-    String jobId = PortabilityApiUtils.validateJobId(httpHeaders, tokenManager);
+    PortabilityApiUtils.validateJobId(httpHeaders, tokenManager);
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void validateJobIdMissingCookieTest(){
-    TokenManager     tokenManager = new JWTTokenManager("TestSecret");
-
-    LegacyPortabilityJob testJob = LegacyPortabilityJob.builder().setId("123456").build();
+    TokenManager tokenManager = new JWTTokenManager("TestSecret");
 
     // create cookies
-    String encodedJobId = JobUtils.encodeId(testJob);;
-    String token = tokenManager.createNewToken(testJob.id());
-    String cookieStr = String
-        .format("%s=%s;", JsonKeys.ID_COOKIE_KEY, encodedJobId);
+    String encodedJobId = JobUtils.encodeId(JOB_ID);;
+    String token = tokenManager.createNewToken(JOB_ID);
+    String cookieStr = String.format("%s=%s;", JsonKeys.ID_COOKIE_KEY, encodedJobId);
 
     // hook up cookies and token header
     Headers httpHeaders = new Headers();
@@ -89,17 +89,16 @@ public class PortabilityApiUtilsTest {
     httpHeaders.add(JsonKeys.XSRF_HEADER, token);
 
     // this should throw IllegalArgumentException due to missing XSRF_TOKEN cookie
-    String jobId = PortabilityApiUtils.validateJobId(httpHeaders, tokenManager);
+    PortabilityApiUtils.validateJobId(httpHeaders, tokenManager);
   }
 
   @Test(expected = NullPointerException.class)
   public void validateJobIdMissingHeaderTest(){
-    TokenManager     tokenManager = new JWTTokenManager("TestSecret");
-    LegacyPortabilityJob testJob = LegacyPortabilityJob.builder().setId("123456").build();
+    TokenManager tokenManager = new JWTTokenManager("TestSecret");
 
     // create cookies
-    String encodedJobId = JobUtils.encodeId(testJob);;
-    String token = tokenManager.createNewToken(testJob.id());
+    String encodedJobId = JobUtils.encodeId(JOB_ID);
+    String token = tokenManager.createNewToken(JOB_ID);
     String cookieStr = String
         .format("%s=%s;%s=%s", JsonKeys.ID_COOKIE_KEY, encodedJobId, JsonKeys.XSRF_TOKEN, token);
 
@@ -108,6 +107,6 @@ public class PortabilityApiUtilsTest {
     httpHeaders.add(HEADER_COOKIE, cookieStr);
 
     // this should throw NullPointerException due to missing X-XSRF-TOKEN header
-    String jobId = PortabilityApiUtils.validateJobId(httpHeaders, tokenManager);
+    PortabilityApiUtils.validateJobId(httpHeaders, tokenManager);
   }
 }

--- a/portability-api/src/test/java/org/dataportabilityproject/webapp/PortabilityApiUtilsTest.java
+++ b/portability-api/src/test/java/org/dataportabilityproject/webapp/PortabilityApiUtilsTest.java
@@ -36,7 +36,7 @@ public class PortabilityApiUtilsTest {
     TokenManager tokenManager = new JWTTokenManager("TestSecret");
 
     // create cookies
-    String encodedJobId = JobUtils.encodeId(JOB_ID);;
+    String encodedJobId = JobUtils.encodeJobId(JOB_ID);;
     String token = tokenManager.createNewToken(JOB_ID);
     String cookieStr = String
         .format("%s=%s;%s=%s", JsonKeys.ID_COOKIE_KEY, encodedJobId, JsonKeys.XSRF_TOKEN, token);
@@ -55,7 +55,7 @@ public class PortabilityApiUtilsTest {
     TokenManager tokenManager = new JWTTokenManager("TestSecret");
 
     // create cookies - purposefully create a token thats not for the correct job ID.
-    String encodedJobId = JobUtils.encodeId(JOB_ID);
+    String encodedJobId = JobUtils.encodeJobId(JOB_ID);
     UUID anotherId = UUID.randomUUID();
     while (anotherId.equals(JOB_ID)) {
       anotherId = UUID.randomUUID();
@@ -79,7 +79,7 @@ public class PortabilityApiUtilsTest {
     TokenManager tokenManager = new JWTTokenManager("TestSecret");
 
     // create cookies
-    String encodedJobId = JobUtils.encodeId(JOB_ID);;
+    String encodedJobId = JobUtils.encodeJobId(JOB_ID);;
     String token = tokenManager.createNewToken(JOB_ID);
     String cookieStr = String.format("%s=%s;", JsonKeys.ID_COOKIE_KEY, encodedJobId);
 
@@ -97,7 +97,7 @@ public class PortabilityApiUtilsTest {
     TokenManager tokenManager = new JWTTokenManager("TestSecret");
 
     // create cookies
-    String encodedJobId = JobUtils.encodeId(JOB_ID);
+    String encodedJobId = JobUtils.encodeJobId(JOB_ID);
     String token = tokenManager.createNewToken(JOB_ID);
     String cookieStr = String
         .format("%s=%s;%s=%s", JsonKeys.ID_COOKIE_KEY, encodedJobId, JsonKeys.XSRF_TOKEN, token);

--- a/portability-core/src/main/java/org/dataportabilityproject/LocalCopier.java
+++ b/portability-core/src/main/java/org/dataportabilityproject/LocalCopier.java
@@ -75,7 +75,7 @@ final class LocalCopier {
           .generateAuthData(ioInterface);
     }
 
-    String jobId = UUID.randomUUID().toString();
+    UUID jobId = UUID.randomUUID();
 
     try {
       logger.info("Starting job {}", jobId);

--- a/portability-core/src/main/java/org/dataportabilityproject/PortabilityCopier.java
+++ b/portability-core/src/main/java/org/dataportabilityproject/PortabilityCopier.java
@@ -17,6 +17,7 @@ package org.dataportabilityproject;
 
 import java.io.IOException;
 import java.util.Optional;
+import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.dataportabilityproject.dataModels.ContinuationInformation;
 import org.dataportabilityproject.dataModels.DataModel;
@@ -41,7 +42,7 @@ public class PortabilityCopier {
       AuthData exportAuthData,
       String importService,
       AuthData importAuthData,
-      String jobId) throws IOException {
+      UUID jobId) throws IOException {
 
     Exporter<T> exporter = registry.getExporter(exportService, dataType, jobId, exportAuthData);
     Importer<T> importer = registry.getImporter(importService, dataType, jobId, importAuthData);

--- a/portability-core/src/main/java/org/dataportabilityproject/ServiceProviderRegistry.java
+++ b/portability-core/src/main/java/org/dataportabilityproject/ServiceProviderRegistry.java
@@ -22,6 +22,7 @@ import com.google.common.collect.ImmutableSet;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
 import org.dataportabilityproject.cloud.interfaces.CloudFactory;
@@ -93,7 +94,7 @@ public class ServiceProviderRegistry {
     public <T extends DataModel> Exporter<T> getExporter(
             String serviceProvider,
             PortableDataType portableDataType,
-            String jobId,
+            UUID jobId,
             AuthData authData) throws IOException {
         JobDataCache jobDataCache = cloudFactory.getJobDataCache(jobId, serviceProvider);
         Exporter<? extends DataModel> exporter = serviceProviders.get(serviceProvider)
@@ -105,7 +106,7 @@ public class ServiceProviderRegistry {
     public <T extends DataModel> Importer<T> getImporter(
             String serviceProvider,
             PortableDataType portableDataType,
-            String jobId,
+            UUID jobId,
             AuthData authData) throws IOException {
         JobDataCache jobDataCache = cloudFactory.getJobDataCache(jobId, serviceProvider);
         Importer<? extends DataModel> importer = serviceProviders.get(serviceProvider)

--- a/portability-core/src/main/java/org/dataportabilityproject/cloud/google/GoogleCloudFactory.java
+++ b/portability-core/src/main/java/org/dataportabilityproject/cloud/google/GoogleCloudFactory.java
@@ -23,6 +23,7 @@ import com.google.cloud.datastore.Key;
 import com.google.cloud.datastore.Query;
 import com.google.cloud.datastore.QueryResults;
 import com.google.cloud.datastore.StructuredQuery.PropertyFilter;
+import java.util.UUID;
 import javax.inject.Inject;
 import org.dataportabilityproject.cloud.google.GoogleCloudModule.ProjectId;
 import org.dataportabilityproject.cloud.interfaces.BucketStore;
@@ -57,7 +58,7 @@ public final class GoogleCloudFactory implements CloudFactory {
   }
 
   @Override
-  public JobDataCache getJobDataCache(String jobId, String service) {
+  public JobDataCache getJobDataCache(UUID jobId, String service) {
     return new GoogleJobDataCache(datastore, jobId, service);
   }
 
@@ -77,12 +78,11 @@ public final class GoogleCloudFactory implements CloudFactory {
   }
 
   @Override
-  public void clearJobData(String jobId) {
+  public void clearJobData(UUID jobId) {
     QueryResults<Key> results = datastore.run(Query.newKeyQueryBuilder()
         .setKind(GoogleJobDataCache.USER_KEY_KIND)
-        .setFilter(PropertyFilter.hasAncestor(
-            datastore.newKeyFactory().setKind(GoogleJobDataCache.JOB_KIND).newKey(jobId)))
-        .build());
+        .setFilter(PropertyFilter.hasAncestor(datastore.newKeyFactory()
+            .setKind(GoogleJobDataCache.JOB_KIND).newKey(jobId.toString()))).build());
     results.forEachRemaining(datastore::delete);
   }
 }

--- a/portability-core/src/main/java/org/dataportabilityproject/cloud/google/GoogleJobDataCache.java
+++ b/portability-core/src/main/java/org/dataportabilityproject/cloud/google/GoogleJobDataCache.java
@@ -31,6 +31,7 @@ import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
+import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import org.dataportabilityproject.cloud.interfaces.JobDataCache;
@@ -61,10 +62,10 @@ public final class GoogleJobDataCache implements JobDataCache {
         }
       });
 
-  public GoogleJobDataCache(Datastore datastore, String jobId, String service) {
+  public GoogleJobDataCache(Datastore datastore, UUID jobId, String service) {
     this.datastore = datastore;
     this.ancestors = ImmutableList.of(
-        PathElement.of(JOB_KIND, jobId),
+        PathElement.of(JOB_KIND, jobId.toString()),
         PathElement.of(SERVICE_KIND, service));
   }
 

--- a/portability-core/src/main/java/org/dataportabilityproject/cloud/interfaces/CloudFactory.java
+++ b/portability-core/src/main/java/org/dataportabilityproject/cloud/interfaces/CloudFactory.java
@@ -15,15 +15,16 @@
  */
 package org.dataportabilityproject.cloud.interfaces;
 
+import java.util.UUID;
 import org.dataportabilityproject.spi.cloud.storage.JobStore;
 
 /**
  * Factory for creating object to interact with cloud implementations.
  */
 public interface CloudFactory {
-  JobDataCache getJobDataCache(String jobId, String service);
+  JobDataCache getJobDataCache(UUID jobId, String service);
   JobStore getJobStore();
   CryptoKeyManagementSystem getCryptoKeyManagementSystem();
   BucketStore getBucketStore();
-  void clearJobData(String jobId);
+  void clearJobData(UUID jobId);
 }

--- a/portability-core/src/main/java/org/dataportabilityproject/cloud/local/InMemoryJobDataCache.java
+++ b/portability-core/src/main/java/org/dataportabilityproject/cloud/local/InMemoryJobDataCache.java
@@ -22,6 +22,7 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
 import java.util.HashMap;
+import java.util.UUID;
 import org.dataportabilityproject.cloud.interfaces.JobDataCache;
 
 public final class InMemoryJobDataCache implements JobDataCache {

--- a/portability-core/src/main/java/org/dataportabilityproject/cloud/local/InMemoryJobDataCache.java
+++ b/portability-core/src/main/java/org/dataportabilityproject/cloud/local/InMemoryJobDataCache.java
@@ -22,7 +22,6 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
 import java.util.HashMap;
-import java.util.UUID;
 import org.dataportabilityproject.cloud.interfaces.JobDataCache;
 
 public final class InMemoryJobDataCache implements JobDataCache {

--- a/portability-core/src/main/java/org/dataportabilityproject/cloud/local/LocalCloudFactory.java
+++ b/portability-core/src/main/java/org/dataportabilityproject/cloud/local/LocalCloudFactory.java
@@ -26,6 +26,7 @@ import com.google.common.base.Suppliers;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
+import java.util.UUID;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import org.dataportabilityproject.cloud.google.GoogleCloudDatastore;
@@ -52,7 +53,7 @@ public class LocalCloudFactory implements CloudFactory {
       CacheBuilder.newBuilder()
       .build(new CacheLoader<String, LoadingCache<String, JobDataCache>>() {
         @Override
-        public LoadingCache<String, JobDataCache> load(String jobId) throws Exception {
+        public LoadingCache<String, JobDataCache> load(String id) throws Exception {
           return CacheBuilder.newBuilder()
               .build(new CacheLoader<String, JobDataCache>() {
                 @Override
@@ -86,7 +87,7 @@ public class LocalCloudFactory implements CloudFactory {
   }
 
   @Override
-  public JobDataCache getJobDataCache(String jobId, String service) {
+  public JobDataCache getJobDataCache(UUID jobId, String service) {
     logger.info("Returning local google datastore-based cache");
     return new GoogleJobDataCache(datastore, jobId, service);
   }
@@ -109,11 +110,11 @@ public class LocalCloudFactory implements CloudFactory {
   }
 
   @Override
-  public void clearJobData(String jobId) {
+  public void clearJobData(UUID jobId) {
     QueryResults<Key> results = datastore.run(Query.newKeyQueryBuilder()
         .setKind(USER_KEY_KIND)
         .setFilter(PropertyFilter.hasAncestor(
-            datastore.newKeyFactory().setKind(JOB_KIND).newKey(jobId)))
+            datastore.newKeyFactory().setKind(JOB_KIND).newKey(jobId.toString())))
         .build());
     results.forEachRemaining(datastore::delete);
   }

--- a/portability-core/src/main/java/org/dataportabilityproject/job/IdProvider.java
+++ b/portability-core/src/main/java/org/dataportabilityproject/job/IdProvider.java
@@ -15,8 +15,10 @@
  */
 package org.dataportabilityproject.job;
 
+import java.util.UUID;
+
 /** Provides ids for users of data portability project. */
 public interface IdProvider {
   /** Creates a new unique id. */
-  String createId();
+  UUID createId();
 }

--- a/portability-core/src/main/java/org/dataportabilityproject/job/JWTTokenManager.java
+++ b/portability-core/src/main/java/org/dataportabilityproject/job/JWTTokenManager.java
@@ -24,6 +24,7 @@ import com.auth0.jwt.interfaces.Claim;
 import com.auth0.jwt.interfaces.DecodedJWT;
 import java.io.UnsupportedEncodingException;
 import java.util.Date;
+import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -83,7 +84,7 @@ public class JWTTokenManager implements TokenManager {
   }
 
   @Override
-  public String getData(String token) {
+  public UUID getData(String token) {
     try {
       DecodedJWT jwt = verifier.verify(token);
       // Token is verified, get claim
@@ -91,7 +92,7 @@ public class JWTTokenManager implements TokenManager {
       if (claim.isNull()) {
         return null;
       }
-      return claim.isNull() ? null : claim.asString();
+      return claim.isNull() ? null : UUID.fromString(claim.asString());
     } catch (JWTVerificationException exception) {
 
       throw new RuntimeException("Error verifying token: " + token);
@@ -99,11 +100,11 @@ public class JWTTokenManager implements TokenManager {
   }
 
   @Override
-  public String createNewToken(String uuid) {
+  public String createNewToken(UUID uuid) {
     try {
       return JWT.create()
           .withIssuer(JWTTokenManager.ISSUER)
-          .withClaim(JWTTokenManager.ID_CLAIM_KEY, uuid)
+          .withClaim(JWTTokenManager.ID_CLAIM_KEY, uuid.toString())
           .withExpiresAt(new Date(System.currentTimeMillis() + EXPIRATION_TIME_MILLIS))
           .sign(algorithm);
     } catch (JWTCreationException e) {

--- a/portability-core/src/main/java/org/dataportabilityproject/job/JWTTokenManager.java
+++ b/portability-core/src/main/java/org/dataportabilityproject/job/JWTTokenManager.java
@@ -84,7 +84,7 @@ public class JWTTokenManager implements TokenManager {
   }
 
   @Override
-  public UUID getData(String token) {
+  public UUID getJobIdFromToken(String token) {
     try {
       DecodedJWT jwt = verifier.verify(token);
       // Token is verified, get claim
@@ -100,15 +100,15 @@ public class JWTTokenManager implements TokenManager {
   }
 
   @Override
-  public String createNewToken(UUID uuid) {
+  public String createNewToken(UUID jobId) {
     try {
       return JWT.create()
           .withIssuer(JWTTokenManager.ISSUER)
-          .withClaim(JWTTokenManager.ID_CLAIM_KEY, uuid.toString())
+          .withClaim(JWTTokenManager.ID_CLAIM_KEY, jobId.toString())
           .withExpiresAt(new Date(System.currentTimeMillis() + EXPIRATION_TIME_MILLIS))
           .sign(algorithm);
     } catch (JWTCreationException e) {
-      throw new RuntimeException("Error creating token for: " + uuid);
+      throw new RuntimeException("Error creating token for: " + jobId);
     }
   }
 }

--- a/portability-core/src/main/java/org/dataportabilityproject/job/JobUtils.java
+++ b/portability-core/src/main/java/org/dataportabilityproject/job/JobUtils.java
@@ -21,6 +21,7 @@ import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.io.BaseEncoding;
+import java.util.UUID;
 import org.dataportabilityproject.shared.PortableDataType;
 import org.dataportabilityproject.shared.ServiceMode;
 import org.dataportabilityproject.spi.cloud.types.LegacyPortabilityJob;
@@ -34,14 +35,14 @@ import org.slf4j.LoggerFactory;
 public final class JobUtils {
   private static final Logger logger = LoggerFactory.getLogger(JobUtils.class);
 
-  public static String decodeId(String encoded) {
+  public static UUID decodeId(String encoded) {
     Preconditions.checkArgument(!Strings.isNullOrEmpty(encoded));
-    return new String(BaseEncoding.base64Url().decode(encoded), Charsets.UTF_8);
+    return UUID.fromString(new String(BaseEncoding.base64Url().decode(encoded), Charsets.UTF_8));
   }
 
-  public static String encodeId(LegacyPortabilityJob job) {
-    Preconditions.checkArgument(!Strings.isNullOrEmpty(job.id()));
-    return BaseEncoding.base64Url().encode(job.id().getBytes(Charsets.UTF_8));
+  public static String encodeId(UUID jobId) {
+    Preconditions.checkNotNull(jobId);
+    return BaseEncoding.base64Url().encode(jobId.toString().getBytes(Charsets.UTF_8));
   }
 
   /* Returns the initial auth data for export or import determined by the {@code serviceMode} param. */

--- a/portability-core/src/main/java/org/dataportabilityproject/job/JobUtils.java
+++ b/portability-core/src/main/java/org/dataportabilityproject/job/JobUtils.java
@@ -35,12 +35,16 @@ import org.slf4j.LoggerFactory;
 public final class JobUtils {
   private static final Logger logger = LoggerFactory.getLogger(JobUtils.class);
 
-  public static UUID decodeId(String encoded) {
+  public static String decodeBase64(String encoded) {
     Preconditions.checkArgument(!Strings.isNullOrEmpty(encoded));
-    return UUID.fromString(new String(BaseEncoding.base64Url().decode(encoded), Charsets.UTF_8));
+    return new String(BaseEncoding.base64Url().decode(encoded), Charsets.UTF_8);
   }
 
-  public static String encodeId(UUID jobId) {
+  public static UUID decodeJobId(String encodedJobId) {
+    return UUID.fromString(decodeBase64(encodedJobId));
+  }
+
+  public static String encodeJobId(UUID jobId) {
     Preconditions.checkNotNull(jobId);
     return BaseEncoding.base64Url().encode(jobId.toString().getBytes(Charsets.UTF_8));
   }

--- a/portability-core/src/main/java/org/dataportabilityproject/job/PortabilityJobFactory.java
+++ b/portability-core/src/main/java/org/dataportabilityproject/job/PortabilityJobFactory.java
@@ -42,7 +42,7 @@ public class PortabilityJobFactory {
     String encodedSessionKey = SecretKeyGenerator.generateKeyAndEncode();
     LegacyPortabilityJob job =
         createInitialJob(encodedSessionKey, dataType, exportService, importService);
-    logger.info("Creating new OldPortabilityJob to transfer {} from {} to {}",
+    logger.info("Creating new LegacyPortabilityJob to transfer {} from {} to {}",
         dataType, exportService, importService);
     return job;
   }

--- a/portability-core/src/main/java/org/dataportabilityproject/job/PortabilityJobFactory.java
+++ b/portability-core/src/main/java/org/dataportabilityproject/job/PortabilityJobFactory.java
@@ -17,6 +17,8 @@ package org.dataportabilityproject.job;
 
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
 import java.io.IOException;
 import org.dataportabilityproject.shared.PortableDataType;
 import org.dataportabilityproject.spi.cloud.types.LegacyPortabilityJob;
@@ -26,72 +28,37 @@ import org.slf4j.LoggerFactory;
 /**
  * Provides methods for the creation of new {@link LegacyPortabilityJob} objects in correct initial state.
  */
+@Singleton
 public class PortabilityJobFactory {
   private final Logger logger = LoggerFactory.getLogger(PortabilityJobFactory.class);
-  // Keys for specific values in data store
-  private static final String ID_DATA_KEY = "UUID";
-  private static final String TOKEN_DATA_KEY = "TOKEN";
-  private static final String DATA_TYPE_DATA_KEY = "DATA_TYPE";
-  private static final String EXPORT_SERVICE_DATA_KEY = "EXPORT_SERVICE";
-  private static final String EXPORT_ACCOUNT_DATA_KEY = "EXPORT_ACCOUNT";
-  private static final String EXPORT_INITIAL_AUTH_DATA_KEY = "EXPORT_INITIAL_AUTH_DATA";
-  private static final String EXPORT_AUTH_DATA_KEY = "EXPORT_AUTH_DATA";
-  private static final String IMPORT_SERVICE_DATA_KEY = "IMPORT_SERVICE";
-  private static final String IMPORT_ACCOUNT_DATA_KEY = "IMPORT_ACCOUNT";
-  private static final String IMPORT_INITIAL_AUTH_DATA_KEY = "IMPORT_INITIAL_AUTH_DATA";
-  private static final String IMPORT_AUTH_DATA_KEY = "IMPORT_AUTH_DATA";
 
-  private final IdProvider idProvider;
-
-  public PortabilityJobFactory(IdProvider idProvider) {
-    this.idProvider = idProvider;
-  }
+  @Inject public PortabilityJobFactory() {}
 
   /**
    * Creates a new user job in initial state with session key.
    */
   public LegacyPortabilityJob create(PortableDataType dataType, String exportService,
       String importService) throws IOException {
-    String newId = idProvider.createId();
     String encodedSessionKey = SecretKeyGenerator.generateKeyAndEncode();
-    LegacyPortabilityJob job = createInitialJob(newId, encodedSessionKey, dataType, exportService, importService);
-    logger.info("Creating new OldPortabilityJob, id: {}", newId);
+    LegacyPortabilityJob job =
+        createInitialJob(encodedSessionKey, dataType, exportService, importService);
+    logger.info("Creating new OldPortabilityJob to transfer {} from {} to {}",
+        dataType, exportService, importService);
     return job;
   }
 
   /** Creates the initial data entry to persist. */
-  private static LegacyPortabilityJob createInitialJob(String id, String sessionKey,
+  private static LegacyPortabilityJob createInitialJob(String sessionKey,
       PortableDataType dataType, String exportService, String importService) {
     Preconditions.checkArgument(!Strings.isNullOrEmpty(sessionKey), "sessionKey missing");
-    Preconditions.checkArgument(!Strings.isNullOrEmpty(id), "id missing");
     Preconditions.checkArgument(!Strings.isNullOrEmpty(exportService), "exportService missing");
     Preconditions.checkArgument(!Strings.isNullOrEmpty(importService), "importService missing");
     Preconditions.checkNotNull(dataType, "dataType missing");
     return LegacyPortabilityJob.builder()
-        .setId(id)
         .setDataType(dataType.name())
         .setExportService(exportService)
         .setImportService(importService)
         .setSessionKey(sessionKey)
         .build();
-  }
-
-  /**
-   * Creates the initial data entry to persist.
-   * @deprecated Remove when encrypted flow complete.
-   */
-  @Deprecated
-  private static LegacyPortabilityJob createInitialJob(String id, PortableDataType dataType,
-      String exportService, String importService) {
-    Preconditions.checkArgument(!Strings.isNullOrEmpty(id), "id missing");
-    Preconditions.checkArgument(!Strings.isNullOrEmpty(exportService), "exportService missing");
-    Preconditions.checkArgument(!Strings.isNullOrEmpty(importService), "importService missing");
-    Preconditions.checkNotNull(dataType, "dataType missing");
-    return LegacyPortabilityJob.builder()
-      .setId(id)
-      .setDataType(dataType.name())
-      .setExportService(exportService)
-      .setImportService(importService)
-      .build();
   }
 }

--- a/portability-core/src/main/java/org/dataportabilityproject/job/TokenManager.java
+++ b/portability-core/src/main/java/org/dataportabilityproject/job/TokenManager.java
@@ -23,9 +23,9 @@ public interface TokenManager {
   /** Verifies if the token is valid. */
   boolean verifyToken(String token);
 
-  /** Verifies and returns the UUID associated with this token. */
-  UUID getData(String token);
+  /** Verifies and returns the jobId associated with this token. */
+  UUID getJobIdFromToken(String token);
 
-  /** Creates a new JWT token with the given {@code uuid}. */
-  String createNewToken(UUID uuid);
+  /** Creates a new JWT token with the given {@code jobId}. */
+  String createNewToken(UUID jobId);
 }

--- a/portability-core/src/main/java/org/dataportabilityproject/job/TokenManager.java
+++ b/portability-core/src/main/java/org/dataportabilityproject/job/TokenManager.java
@@ -15,11 +15,7 @@
  */
 package org.dataportabilityproject.job;
 
-import com.auth0.jwt.JWT;
-import com.auth0.jwt.exceptions.JWTCreationException;
-import com.auth0.jwt.exceptions.JWTVerificationException;
-import com.auth0.jwt.interfaces.Claim;
-import com.auth0.jwt.interfaces.DecodedJWT;
+import java.util.UUID;
 
 /** Functionality to manage the lifecycle of tokens. */
 public interface TokenManager {
@@ -27,9 +23,9 @@ public interface TokenManager {
   /** Verifies if the token is valid. */
   boolean verifyToken(String token);
 
-  /** Verifies and returns the data associated with this token. */
-  String getData(String token);
+  /** Verifies and returns the UUID associated with this token. */
+  UUID getData(String token);
 
   /** Creates a new JWT token with the given {@code uuid}. */
-  String createNewToken(String uuid);
+  String createNewToken(UUID uuid);
 }

--- a/portability-core/src/main/java/org/dataportabilityproject/job/UUIDProvider.java
+++ b/portability-core/src/main/java/org/dataportabilityproject/job/UUIDProvider.java
@@ -21,7 +21,7 @@ import java.util.UUID;
 public class UUIDProvider implements IdProvider {
 
   @Override
-  public String createId() {
-    return UUID.randomUUID().toString();
+  public UUID createId() {
+    return UUID.randomUUID();
   }
 }

--- a/portability-core/src/main/java/org/dataportabilityproject/serviceProviders/flickr/FlickrAuth.java
+++ b/portability-core/src/main/java/org/dataportabilityproject/serviceProviders/flickr/FlickrAuth.java
@@ -26,6 +26,7 @@ import com.flickr4java.flickr.auth.Permission;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import java.io.IOException;
+import java.util.UUID;
 import javax.annotation.Nullable;
 import org.dataportabilityproject.shared.AppCredentials;
 import org.dataportabilityproject.shared.IOInterface;
@@ -87,7 +88,7 @@ final class FlickrAuth implements OfflineAuthDataGenerator, OnlineAuthDataGenera
   }
 
   @Override // online case
-  public AuthFlowInitiator generateAuthUrl(String callbackBaseUrl, String id) throws IOException {
+  public AuthFlowInitiator generateAuthUrl(String callbackBaseUrl, UUID jobId) throws IOException {
     AuthInterface authInterface = flickr.getAuthInterface();
     Token token = authInterface.getRequestToken(
         callbackBaseUrl + "/callback1/flickr");
@@ -97,7 +98,7 @@ final class FlickrAuth implements OfflineAuthDataGenerator, OnlineAuthDataGenera
   }
 
   @Override
-  public AuthData generateAuthData(String callbackBaseUrl, String authCode, String id,
+  public AuthData generateAuthData(String callbackBaseUrl, String authCode, UUID jobId,
       AuthData initialAuthData, @Nullable String extra) throws IOException {
     Preconditions.checkArgument(Strings.isNullOrEmpty(extra), "Extra data not expected");
     Preconditions
@@ -106,7 +107,7 @@ final class FlickrAuth implements OfflineAuthDataGenerator, OnlineAuthDataGenera
     Token token = fromAuthData(initialAuthData);
     Token requestToken = authInterface.getAccessToken(token, new Verifier(authCode));
     try {
-      Auth auth = authInterface.checkToken(requestToken);
+      authInterface.checkToken(requestToken);
       return TokenSecretAuthData.create(requestToken.getToken(), requestToken.getSecret());
     } catch (FlickrException e) {
       throw new IOException("Problem verifying auth token", e);

--- a/portability-core/src/main/java/org/dataportabilityproject/serviceProviders/google/GoogleAuth.java
+++ b/portability-core/src/main/java/org/dataportabilityproject/serviceProviders/google/GoogleAuth.java
@@ -71,7 +71,7 @@ class GoogleAuth implements OfflineAuthDataGenerator, OnlineAuthDataGenerator {
 
   @Override
   public AuthFlowInitiator generateAuthUrl(String callbackBaseUrl, UUID jobId) throws IOException {
-    String encodedJobId = JobUtils.encodeId(jobId);
+    String encodedJobId = JobUtils.encodeJobId(jobId);
     String url = createFlow()
         .newAuthorizationUrl()
         .setRedirectUri(callbackBaseUrl + CALLBACK_PATH)

--- a/portability-core/src/main/java/org/dataportabilityproject/serviceProviders/instagram/InstagramAuth.java
+++ b/portability-core/src/main/java/org/dataportabilityproject/serviceProviders/instagram/InstagramAuth.java
@@ -33,6 +33,8 @@ import com.google.common.collect.ImmutableList;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 import java.util.List;
+import java.util.UUID;
+import org.dataportabilityproject.job.JobUtils;
 import org.dataportabilityproject.shared.AppCredentials;
 import org.dataportabilityproject.shared.IOInterface;
 import org.dataportabilityproject.shared.auth.AuthFlowInitiator;
@@ -103,17 +105,18 @@ final class InstagramAuth implements OfflineAuthDataGenerator, OnlineAuthDataGen
   }
 
   @Override
-  public AuthFlowInitiator generateAuthUrl(String callbackBaseUrl, String id) throws IOException {
+  public AuthFlowInitiator generateAuthUrl(String callbackBaseUrl, UUID jobId) throws IOException {
+    String encodedJobId = JobUtils.encodeId(jobId);
     String url = createFlow()
         .newAuthorizationUrl()
         .setRedirectUri(callbackBaseUrl + CALLBACK_PATH)
-        .setState(id) // TODO: Encrypt
+        .setState(encodedJobId) // TODO: Encrypt
         .build();
     return AuthFlowInitiator.create(url);
   }
 
   @Override
-  public AuthData generateAuthData(String callbackBaseUrl, String authCode, String id,
+  public AuthData generateAuthData(String callbackBaseUrl, String authCode, UUID jobId,
       AuthData initialAuthData,
       String extra) throws IOException {
     Preconditions.checkArgument(Strings.isNullOrEmpty(extra),
@@ -126,7 +129,7 @@ final class InstagramAuth implements OfflineAuthDataGenerator, OnlineAuthDataGen
         .setRedirectUri(callbackBaseUrl + CALLBACK_PATH) //TODO(chuy): Parameterize
         .execute();
     // Figure out storage
-    Credential credential = flow.createAndStoreCredential(response, id);
+    Credential credential = flow.createAndStoreCredential(response, jobId.toString());
     return toAuthData(credential);
   }
 

--- a/portability-core/src/main/java/org/dataportabilityproject/serviceProviders/instagram/InstagramAuth.java
+++ b/portability-core/src/main/java/org/dataportabilityproject/serviceProviders/instagram/InstagramAuth.java
@@ -106,7 +106,7 @@ final class InstagramAuth implements OfflineAuthDataGenerator, OnlineAuthDataGen
 
   @Override
   public AuthFlowInitiator generateAuthUrl(String callbackBaseUrl, UUID jobId) throws IOException {
-    String encodedJobId = JobUtils.encodeId(jobId);
+    String encodedJobId = JobUtils.encodeJobId(jobId);
     String url = createFlow()
         .newAuthorizationUrl()
         .setRedirectUri(callbackBaseUrl + CALLBACK_PATH)

--- a/portability-core/src/main/java/org/dataportabilityproject/serviceProviders/microsoft/MicrosoftAuth.java
+++ b/portability-core/src/main/java/org/dataportabilityproject/serviceProviders/microsoft/MicrosoftAuth.java
@@ -78,7 +78,7 @@ final class MicrosoftAuth implements OfflineAuthDataGenerator, OnlineAuthDataGen
 
   @Override
   public AuthFlowInitiator generateAuthUrl(String callbackBaseUrl, UUID jobId) throws IOException {
-    String encodedJobId = JobUtils.encodeId(jobId);
+    String encodedJobId = JobUtils.encodeJobId(jobId);
     String url = createFlow()
         .newAuthorizationUrl()
         .setRedirectUri(callbackBaseUrl + CALLBACK_PATH)

--- a/portability-core/src/main/java/org/dataportabilityproject/serviceProviders/microsoft/MicrosoftAuth.java
+++ b/portability-core/src/main/java/org/dataportabilityproject/serviceProviders/microsoft/MicrosoftAuth.java
@@ -29,6 +29,8 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import java.io.IOException;
 import java.util.List;
+import java.util.UUID;
+import org.dataportabilityproject.job.JobUtils;
 import org.dataportabilityproject.shared.AppCredentials;
 import org.dataportabilityproject.shared.IOInterface;
 import org.dataportabilityproject.shared.auth.AuthFlowInitiator;
@@ -75,17 +77,18 @@ final class MicrosoftAuth implements OfflineAuthDataGenerator, OnlineAuthDataGen
   }
 
   @Override
-  public AuthFlowInitiator generateAuthUrl(String callbackBaseUrl, String id) throws IOException {
+  public AuthFlowInitiator generateAuthUrl(String callbackBaseUrl, UUID jobId) throws IOException {
+    String encodedJobId = JobUtils.encodeId(jobId);
     String url = createFlow()
         .newAuthorizationUrl()
         .setRedirectUri(callbackBaseUrl + CALLBACK_PATH)
-        .setState(id) // TODO: Encrypt
+        .setState(encodedJobId) // TODO: Encrypt
         .build();
     return AuthFlowInitiator.create(url);
   }
 
   @Override
-  public AuthData generateAuthData(String callbackBaseUrl, String authCode, String id,
+  public AuthData generateAuthData(String callbackBaseUrl, String authCode, UUID jobId,
       AuthData initialAuthData, String extra)
       throws IOException {
     Preconditions
@@ -98,7 +101,7 @@ final class MicrosoftAuth implements OfflineAuthDataGenerator, OnlineAuthDataGen
         .setRedirectUri(callbackBaseUrl + CALLBACK_PATH) //TODO(chuy): Parameterize
         .execute();
     // Figure out storage
-    Credential credential = flow.createAndStoreCredential(response, id);
+    Credential credential = flow.createAndStoreCredential(response, jobId.toString());
     // Extract the Google User ID from the ID token in the auth response
     // GoogleIdToken.Payload payload = ((GoogleTokenResponse) response).parseIdToken().getPayload();
     return toAuthData(credential);

--- a/portability-core/src/main/java/org/dataportabilityproject/shared/auth/OnlineAuthDataGenerator.java
+++ b/portability-core/src/main/java/org/dataportabilityproject/shared/auth/OnlineAuthDataGenerator.java
@@ -16,6 +16,7 @@
 package org.dataportabilityproject.shared.auth;
 
 import java.io.IOException;
+import java.util.UUID;
 import org.dataportabilityproject.types.transfer.auth.AuthData;
 
 /** Methods to generate AuthData for online */
@@ -24,19 +25,19 @@ public interface OnlineAuthDataGenerator {
    * Provide a authUrl to redirect the user to authenticate. In the Oauth2 case,
    * this is the authorization code authUrl.
    *  @param callbackBaseUrl the url to the api server serving the callback for the auth request
-   *  @param id is a client supplied identifier
+   *  @param jobId the ID of the PortabilityJob
    */
-  AuthFlowInitiator generateAuthUrl(String callbackBaseUrl, String id) throws IOException;
+  AuthFlowInitiator generateAuthUrl(String callbackBaseUrl, UUID jobId) throws IOException;
 
   /**
    * Generate auth data given the code, identifier, and, optional, initial auth data that was
    * used for earlier steps of the authentication flow.
    *  @param callbackBaseUrl the url to the api server serving the callback for the auth request
    * @param authCode The authorization code or oauth verififer after user authorization
-   * @param id is a client supplied identifier
+   * @param jobId the ID of the PortabilityJob
    * @param initialAuthData optional data resulting from the initial auth step
    * @param extra optional additional code, password, etc.
    */
-  public AuthData generateAuthData(String callbackBaseUrl, String authCode, String id,
+  AuthData generateAuthData(String callbackBaseUrl, String authCode, UUID jobId,
       AuthData initialAuthData, String extra) throws IOException;
 }

--- a/portability-core/src/main/java/org/dataportabilityproject/shared/auth/PasswordAuthDataGenerator.java
+++ b/portability-core/src/main/java/org/dataportabilityproject/shared/auth/PasswordAuthDataGenerator.java
@@ -17,6 +17,7 @@ package org.dataportabilityproject.shared.auth;
 
 import com.google.common.base.Preconditions;
 import java.io.IOException;
+import java.util.UUID;
 import org.dataportabilityproject.shared.IOInterface;
 import org.dataportabilityproject.types.transfer.auth.AuthData;
 
@@ -30,12 +31,12 @@ public final class PasswordAuthDataGenerator implements OnlineAuthDataGenerator,
   }
 
   @Override
-  public AuthFlowInitiator generateAuthUrl(String callbackBaseUrl, String id) throws IOException {
+  public AuthFlowInitiator generateAuthUrl(String callbackBaseUrl, UUID jobId) throws IOException {
     return AuthFlowInitiator.create(callbackBaseUrl + "/simplelogin");
   }
 
   @Override // online
-  public AuthData generateAuthData(String callbackBaseUrl, String authCode, String id,
+  public AuthData generateAuthData(String callbackBaseUrl, String authCode, UUID jobId,
       AuthData initialAuthData, String extra) throws IOException {
     Preconditions.checkArgument(initialAuthData == null, "initial auth data not expected");
     return PasswordAuthData.create(authCode, extra);

--- a/portability-core/src/test/java/org/dataportabilityproject/job/JobUtilsTest.java
+++ b/portability-core/src/test/java/org/dataportabilityproject/job/JobUtilsTest.java
@@ -15,7 +15,7 @@ public class JobUtilsTest {
   @Test
   public void encodeDecodeRoundTrip() throws Exception {
     UUID jobId = UUID.randomUUID();
-    assertThat(JobUtils.decodeId(JobUtils.encodeId(jobId))).isEqualTo(jobId);
+    assertThat(JobUtils.decodeJobId(JobUtils.encodeJobId(jobId))).isEqualTo(jobId);
   }
 
   @Test

--- a/portability-core/src/test/java/org/dataportabilityproject/job/JobUtilsTest.java
+++ b/portability-core/src/test/java/org/dataportabilityproject/job/JobUtilsTest.java
@@ -4,6 +4,7 @@ import static com.google.common.truth.Truth.assertThat;
 import static org.dataportabilityproject.shared.ServiceMode.EXPORT;
 import static org.dataportabilityproject.shared.ServiceMode.IMPORT;
 
+import java.util.UUID;
 import org.dataportabilityproject.shared.auth.PasswordAuthData;
 import org.dataportabilityproject.shared.auth.TokenSecretAuthData;
 import org.dataportabilityproject.spi.cloud.types.LegacyPortabilityJob;
@@ -13,33 +14,30 @@ import org.junit.Test;
 public class JobUtilsTest {
   @Test
   public void encodeDecodeRoundTrip() throws Exception {
-    String jobId = "This is my @$*(#$ job id \t\n";
-    LegacyPortabilityJob job = LegacyPortabilityJob.builder()
-        .setId(jobId)
-        .build();
-    assertThat(JobUtils.decodeId(JobUtils.encodeId(job))).isEqualTo(jobId);
+    UUID jobId = UUID.randomUUID();
+    assertThat(JobUtils.decodeId(JobUtils.encodeId(jobId))).isEqualTo(jobId);
   }
 
   @Test
   public void passwordAuthDataRoundTrip() throws Exception {
-    LegacyPortabilityJob importJob = LegacyPortabilityJob.builder().setId("id").build();
+    LegacyPortabilityJob importJob = LegacyPortabilityJob.builder().build();
     AuthData authData = PasswordAuthData.create("myUsername", "myPassword");
     assertThat(JobUtils.getInitialAuthData(
         JobUtils.setInitialAuthData(importJob, authData, IMPORT), IMPORT)).isEqualTo(authData);
 
-    LegacyPortabilityJob exportJob = LegacyPortabilityJob.builder().setId("id").build();
+    LegacyPortabilityJob exportJob = LegacyPortabilityJob.builder().build();
     assertThat(JobUtils.getInitialAuthData(
         JobUtils.setInitialAuthData(exportJob, authData, EXPORT), EXPORT)).isEqualTo(authData);
   }
 
   @Test
   public void tokenAuthDataRoundTrip() throws Exception {
-    LegacyPortabilityJob importJob = LegacyPortabilityJob.builder().setId("id").build();
+    LegacyPortabilityJob importJob = LegacyPortabilityJob.builder().build();
     AuthData authData = TokenSecretAuthData.create("myToken", "mySecret");
     assertThat(JobUtils.getInitialAuthData(
         JobUtils.setInitialAuthData(importJob, authData, IMPORT), IMPORT)).isEqualTo(authData);
 
-    LegacyPortabilityJob exportJob = LegacyPortabilityJob.builder().setId("id").build();
+    LegacyPortabilityJob exportJob = LegacyPortabilityJob.builder().build();
     assertThat(JobUtils.getInitialAuthData(
         JobUtils.setInitialAuthData(exportJob, authData, EXPORT), EXPORT)).isEqualTo(authData);
   }

--- a/portability-spi-cloud/src/main/java/org/dataportabilityproject/spi/cloud/storage/JobStore.java
+++ b/portability-spi-cloud/src/main/java/org/dataportabilityproject/spi/cloud/storage/JobStore.java
@@ -1,5 +1,6 @@
 package org.dataportabilityproject.spi.cloud.storage;
 
+import java.util.UUID;
 import org.dataportabilityproject.spi.cloud.types.LegacyPortabilityJob;
 import org.dataportabilityproject.spi.cloud.types.LegacyPortabilityJob.JobState;
 import org.dataportabilityproject.spi.cloud.types.PortabilityJob;
@@ -11,7 +12,8 @@ import java.io.InputStream;
 /**
  * Implementations handle storage and retrieval of {@link LegacyPortabilityJob}s.
  *
- * This class is intended to be implemented by extensions that support storage in various back-end services.
+ * This class is intended to be implemented by extensions that support storage in various back-end
+ * services.
  */
 public interface JobStore {
 
@@ -23,7 +25,7 @@ public interface JobStore {
      * @throws IOException if a job already exists for {@code job}'s ID, or if there was a different
      * problem inserting the job.
      */
-    void create(LegacyPortabilityJob job) throws IOException;
+    void create(UUID jobId, LegacyPortabilityJob job) throws IOException;
 
     /**
      * Inserts a new {@link PortabilityJob} keyed by its job ID in the store.
@@ -33,7 +35,7 @@ public interface JobStore {
      * @throws IOException if a job already exists for {@code job}'s ID, or if there was a different
      * problem inserting the job.
      */
-    default void createJob(PortabilityJob job) throws IOException {
+    default void createJob(UUID jobId, PortabilityJob job) throws IOException {
 
     }
 
@@ -44,7 +46,7 @@ public interface JobStore {
      * @throws IOException if the job was not in the expected state in the store, or there was
      * another problem updating it.
      */
-    void update(LegacyPortabilityJob job, JobState previousState) throws IOException;
+    void update(UUID jobId, LegacyPortabilityJob job, JobState previousState) throws IOException;
 
     /**
      * Atomically updates the entry for {@code job}'s ID to {@code job}.
@@ -52,7 +54,7 @@ public interface JobStore {
      * @throws IOException if the job was not in the expected state in the store, or there was
      * another problem updating it.
      */
-    default void updateJob(PortabilityJob job) throws IOException {
+    default void updateJob(UUID jobId, PortabilityJob job) throws IOException {
     }
 
     /**
@@ -60,67 +62,65 @@ public interface JobStore {
      *
      * @throws IOException if the job doesn't exist, or there was a different problem deleting it.
      */
-    void remove(String jobId) throws IOException;
+    void remove(UUID jobId) throws IOException;
 
     /**
      * Returns the job for the id or null if not found.
      *
      * @param id the job id
      */
-    default PortabilityJob findJob(String id) {
+    default PortabilityJob findJob(UUID id) {
         throw new UnsupportedOperationException();
     }
 
     /**
-     * Finds the {@link LegacyPortabilityJob} keyed by {@code jobId} in the store, or null if none found.
+     * Finds the {@link LegacyPortabilityJob} keyed by {@code jobId} in the store, or null if none
+     * found.
      */
-    LegacyPortabilityJob find(String jobId);
+    LegacyPortabilityJob find(UUID jobId);
 
     /**
-     * Gets the ID of the first {@link LegacyPortabilityJob} in state {@code jobState} in the store, or
-     * null if none found.
+     * Gets the ID of the first {@link LegacyPortabilityJob} in state {@code jobState} in the store,
+     * or null if none found.
      */
-    String findFirst(JobState jobState);
+    UUID findFirst(JobState jobState);
 
-    default <T extends DataModel> void create(String jobId, T model) {
+    default <T extends DataModel> void create(UUID jobId, T model) {
         throw new UnsupportedOperationException();
     }
 
     /**
      * Updates the given model instance associated with a job.
      */
-    default <T extends DataModel> void update(String jobId, T model) {
+    default <T extends DataModel> void update(UUID jobId, T model) {
         throw new UnsupportedOperationException();
     }
 
     /**
      * Returns a model instance for the id of the given type or null if not found.
      */
-    default <T extends DataModel> T findData(Class<T> type, String id) {
+    default <T extends DataModel> T findData(Class<T> type, UUID id) {
         throw new UnsupportedOperationException();
     }
 
     /**
      * Removes the data model instance.
      */
-    default void removeData(String id) {
+    default void removeData(UUID id) {
         throw new UnsupportedOperationException();
-
     }
 
     /**
-     * Finds the {@link LegacyPortabilityJob} keyed by {@code jobId} in the store, and verify it is in
-     * state {@code jobState}.
+     * Finds the {@link LegacyPortabilityJob} keyed by {@code jobId} in the store, and verify it is
+     * in state {@code jobState}.
      */
-    LegacyPortabilityJob find(String jobId, JobState jobState);
+    LegacyPortabilityJob find(UUID jobId, JobState jobState);
 
-    default void create(String jobId, String key, InputStream stream) {
+    default void create(UUID jobId, String key, InputStream stream) {
         throw new UnsupportedOperationException();
     }
 
-    default InputStream getStream(String jobId, String key) {
+    default InputStream getStream(UUID jobId, String key) {
         throw new UnsupportedOperationException();
     }
-
-
 }

--- a/portability-spi-cloud/src/main/java/org/dataportabilityproject/spi/cloud/types/LegacyPortabilityJob.java
+++ b/portability-spi-cloud/src/main/java/org/dataportabilityproject/spi/cloud/types/LegacyPortabilityJob.java
@@ -33,9 +33,7 @@ public abstract class LegacyPortabilityJob {
     ASSIGNED_WITH_AUTH_DATA,
   }
 
-  public abstract String id();
-  @Nullable
-  public abstract String dataType();
+  @Nullable public abstract String dataType();
   @Nullable public abstract String exportService();
   @Nullable public abstract String exportAccount();
   @Nullable public abstract AuthData exportInitialAuthData();
@@ -62,7 +60,6 @@ public abstract class LegacyPortabilityJob {
 
   @AutoValue.Builder
   public abstract static class Builder {
-    public abstract LegacyPortabilityJob.Builder setId(String id);
     public abstract LegacyPortabilityJob.Builder setDataType(String id);
     public abstract LegacyPortabilityJob.Builder setExportService(String id);
     public abstract LegacyPortabilityJob.Builder setExportAccount(String id);
@@ -86,9 +83,7 @@ public abstract class LegacyPortabilityJob {
 
     /** Validates required values on build. */
     public LegacyPortabilityJob build() {
-      LegacyPortabilityJob job = autoBuild();
-      Preconditions.checkState(!Strings.isNullOrEmpty(job.id()), "Invalid id value");
-      return job;
+      return autoBuild();
     }
   }
 

--- a/portability-spi-cloud/src/main/java/org/dataportabilityproject/spi/cloud/types/OldPortabilityJobConverter.java
+++ b/portability-spi-cloud/src/main/java/org/dataportabilityproject/spi/cloud/types/OldPortabilityJobConverter.java
@@ -15,7 +15,6 @@ import org.dataportabilityproject.types.transfer.auth.AuthData;
 public final class OldPortabilityJobConverter extends
     Converter<LegacyPortabilityJob, Map<String, Object>> {
   // Keys for specific values in the key value store
-  public static final String ID_DATA_KEY = "UUID";
   private static final String DATA_TYPE_DATA_KEY = "DATA_TYPE";
   private static final String EXPORT_SERVICE_DATA_KEY = "EXPORT_SERVICE";
   private static final String EXPORT_ACCOUNT_DATA_KEY = "EXPORT_ACCOUNT";
@@ -38,10 +37,6 @@ public final class OldPortabilityJobConverter extends
   @Override
   protected Map<String, Object> doForward(LegacyPortabilityJob job) {
     ImmutableMap.Builder<String, Object> builder = ImmutableMap.builder();
-
-    // Id is the key so it is required
-    Preconditions.checkArgument(!Strings.isNullOrEmpty(job.id()), "Invalid uuid");
-    builder.put(ID_DATA_KEY, job.id());
 
     // Data type may not be set during initial flow
     if(!Strings.isNullOrEmpty(job.dataType())) {
@@ -101,10 +96,8 @@ public final class OldPortabilityJobConverter extends
    */
   @Override
   protected LegacyPortabilityJob doBackward(Map<String, Object> data) {
-    Preconditions.checkArgument(!isStringValueNullOrEmpty(data, ID_DATA_KEY), "uuid missing");
     // Add required data
     LegacyPortabilityJob.Builder builder = LegacyPortabilityJob.builder();
-    builder.setId(getString(data, ID_DATA_KEY));
 
     // newly created sessions will not contain any data type selection
     String dataType = getString(data, DATA_TYPE_DATA_KEY);

--- a/portability-spi-transfer/src/main/java/org/dataportabilityproject/spi/transfer/InMemoryTransferCopier.java
+++ b/portability-spi-transfer/src/main/java/org/dataportabilityproject/spi/transfer/InMemoryTransferCopier.java
@@ -16,6 +16,7 @@
 package org.dataportabilityproject.spi.transfer;
 
 import java.io.IOException;
+import java.util.UUID;
 import org.dataportabilityproject.spi.transfer.provider.TransferServiceProvider;
 import org.dataportabilityproject.spi.transfer.provider.TransferServiceProviderRegistry;
 import org.dataportabilityproject.types.transfer.PortableType;
@@ -33,5 +34,5 @@ public interface InMemoryTransferCopier {
       AuthData exportAuthData,
       String importService,
       AuthData importAuthData,
-      String jobId) throws IOException;
+      UUID jobId) throws IOException;
 }

--- a/portability-types-transfer/src/main/java/org/dataportabilityproject/types/transfer/EntityType.java
+++ b/portability-types-transfer/src/main/java/org/dataportabilityproject/types/transfer/EntityType.java
@@ -15,26 +15,10 @@
  */
 package org.dataportabilityproject.types.transfer;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-
 /**
  * A uniquely identifiable entity in the system.
+ *
+ * TODO(rtannenbaum): Remove this class (current PR has a lot in it, do it in a separate one)
  */
 public abstract class EntityType extends PortableType {
-    @JsonProperty
-    private String id;
-
-    /**
-     * Returns the unique identifier. A null value indicates the entity has not been persisted.
-     */
-    public String getId() {
-        return id;
-    }
-
-    /**
-     * Sets the unique identifier.
-     */
-    public void setId(String id) {
-        this.id = id;
-    }
 }

--- a/portability-worker/src/main/java/org/dataportabilityproject/worker/PortabilityInMemoryTransferCopier.java
+++ b/portability-worker/src/main/java/org/dataportabilityproject/worker/PortabilityInMemoryTransferCopier.java
@@ -16,6 +16,7 @@
 package org.dataportabilityproject.worker;
 
 import java.io.IOException;
+import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.dataportabilityproject.spi.transfer.InMemoryTransferCopier;
 import org.dataportabilityproject.spi.transfer.provider.ExportResult;
@@ -57,7 +58,7 @@ public class PortabilityInMemoryTransferCopier implements InMemoryTransferCopier
       AuthData exportAuthData,
       String importService,
       AuthData importAuthData,
-      String jobId) throws IOException {
+      UUID jobId) throws IOException {
 
     Exporter<? extends AuthData, ? extends DataModel> exporter = registry.getExporter(exportService, dataType);
     Importer<? extends AuthData, ? extends DataModel> importer = registry.getImporter(importService, dataType);

--- a/portability-worker/src/main/java/org/dataportabilityproject/worker/WorkerJobMetadata.java
+++ b/portability-worker/src/main/java/org/dataportabilityproject/worker/WorkerJobMetadata.java
@@ -19,6 +19,7 @@ import com.google.common.base.Preconditions;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import java.security.KeyPair;
+import java.util.UUID;
 import org.dataportabilityproject.job.PublicPrivateKeyPairGenerator;
 
 /**
@@ -28,7 +29,7 @@ import org.dataportabilityproject.job.PublicPrivateKeyPairGenerator;
 @Singleton
 final class WorkerJobMetadata {
   private static KeyPair keyPair = null;
-  private static String jobId = null;
+  private static UUID jobId = null;
 
   @Inject
   WorkerJobMetadata() {}
@@ -37,7 +38,7 @@ final class WorkerJobMetadata {
     return (jobId != null && keyPair != null);
   }
 
-  void init(String jobId, KeyPair keyPair) {
+  void init(UUID jobId, KeyPair keyPair) {
     Preconditions.checkState(!isInitialized(), "WorkerJobMetadata cannot be initialized twice");
     this.jobId = jobId;
     this.keyPair = keyPair;
@@ -48,7 +49,7 @@ final class WorkerJobMetadata {
     return keyPair;
   }
 
-  public String getJobId() {
+  public UUID getJobId() {
     Preconditions.checkState(isInitialized(), "WorkerJobMetadata must be initialized");
     return jobId;
   }


### PR DESCRIPTION
Remove jobId from PortabilityJob (both LegacyPortabilityJob and the new PortabilityJob via EntityType)

I originally thought this would be necessary for #132, turns out it's not but is still good to do. It is redundant to store jobId in the job as we are keying off of it in our stores.

Also change jobID to be type UUID instead of String, for a few reasons:
- UUIDs are used directly in CosmosStore (no String conversion)
- Prevent ambiguity around whether String jobIDs passed around are base-64 encoded or not
- All impls are using UUID anyway and converting to and from String
- note: Datastore is still storing type String jobId. Might change that later but did not want to break it right now.

Tested locally with encryptionFlow both on & off