### PR TITLE
Prevent error checking missing property JobState for legacy non-encryption flow

### DIFF
--- a/extensions/cloud/portability-cloud-google/src/main/java/org/dataportabilityproject/cloud/google/GoogleCloudDatastore.java
+++ b/extensions/cloud/portability-cloud-google/src/main/java/org/dataportabilityproject/cloud/google/GoogleCloudDatastore.java
@@ -152,7 +152,7 @@ public final class GoogleCloudDatastore implements JobStore {
   }
 
   /**
-   * Atomically updates the {@link LegacyPortabilityJob} keyed by {@code jobId} to {@code OldPortabilityJob},
+   * Atomically updates the {@link LegacyPortabilityJob} keyed by {@code jobId} to {@code job},
    * in Datastore using a {@link Transaction}, and verifies that it was previously in the expected
    * {@code previousState}.
    *
@@ -173,7 +173,7 @@ public final class GoogleCloudDatastore implements JobStore {
         transaction.rollback();
         throw new IOException("Could not find record for jobId " + jobId);
       }
-      if (getJobState(previousEntity) != previousState) {
+      if (previousState != null && getJobState(previousEntity) != previousState) {
         throw new IOException("Job " + jobId + " existed in an unexpected state. "
             + "Expected: " + previousState + " but was: " + getJobState(previousEntity));
       }


### PR DESCRIPTION
I know we are about ready to move away from legacy flow, but might as well fix this