### PR TITLE
Remove last usage of LegacyPortabilityJob in the new code.

### DIFF
--- a/extensions/cloud/portability-cloud-microsoft/src/main/java/org/dataportabilityproject/cloud/microsoft/cosmos/CosmosStore.java
+++ b/extensions/cloud/portability-cloud-microsoft/src/main/java/org/dataportabilityproject/cloud/microsoft/cosmos/CosmosStore.java
@@ -30,7 +30,6 @@ import java.io.InputStream;
 import java.util.UUID;
 import org.dataportabilityproject.spi.cloud.storage.JobStore;
 import org.dataportabilityproject.spi.cloud.types.JobAuthorization;
-import org.dataportabilityproject.spi.cloud.types.LegacyPortabilityJob;
 import org.dataportabilityproject.spi.cloud.types.PortabilityJob;
 import org.dataportabilityproject.types.transfer.models.DataModel;
 
@@ -125,28 +124,7 @@ public class CosmosStore implements JobStore {
     }
 
     @Override
-    public void create(UUID jobId, LegacyPortabilityJob job) throws IOException {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public void update(UUID jobId, LegacyPortabilityJob job,
-        JobAuthorization.State previousState) throws IOException {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public LegacyPortabilityJob find(UUID jobId) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
     public UUID findFirst(JobAuthorization.State jobState) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public LegacyPortabilityJob find(UUID jobId, JobAuthorization.State jobState) {
         throw new UnsupportedOperationException();
     }
 


### PR DESCRIPTION
It is still referenced in the old code. for #132.