### PR TITLE
Fix Intellij issue so we don't have to manually add generated source roots

### DIFF
--- a/Documentation/Developer.md
+++ b/Documentation/Developer.md
@@ -31,14 +31,6 @@ The following instructions work for IntelliJ IDEA version 2017.2.6.
     * Go to File -> Settings -> Build, Execution, Deployment -> Compiler -> Annotation Processors
     * Check 'Enable annotation processing'
     * Store generated sources relative to: 'Module content root' (not the default)
- 
-#### Optional: Make IDE recognize generated AutoValue classes
-At this point, generated classes from AutoValue will currently be unrecognized by the IDE, which will make them appear underlined in red, but shouldn't cause any further problems. The following steps will make the IDE recognize the generated classes, but note that occasionally you need to do this multiple times since IntelliJ seems to forget the setting.
- * Verify an AutoValue class is not recognized yet. e.g. in `PortabilityJob.java`, the generated class `AutoValue_PortabilityJob` should be unrecognized (underlined in red)
- * In the left-hand project menu (Alt+1), right click on the class's module, e.g. `portability-spi-cloud`, and click "Build Module..."
- * Verify there is now a `build/` directory inside the module
- * Right click on `build/classes/java/main` -> Mark Directory as -> Generated sources root
- * Verify `AutoValue_PortabilityJob` is now recognized
 
 ## Environment-specific settings
 Environment-specific settings (values for PortabilityFlags) are stored

--- a/portability-spi-cloud/build.gradle
+++ b/portability-spi-cloud/build.gradle
@@ -24,11 +24,13 @@ dependencies {
 sourceSets {
     main {
         java {
+            // Includes generated AutoValue_ classes (build/classes/java) as source
             srcDirs = ['build/classes/java','src/main/java']
         }
     }
     test {
         java {
+            // Include test directories so we can build and run tests in IDE.
             srcDirs = ['src/test/java']
         }
     }

--- a/portability-spi-cloud/build.gradle
+++ b/portability-spi-cloud/build.gradle
@@ -20,3 +20,16 @@ dependencies {
     compile ("com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}")
     compile("com.google.auto.value:auto-value:${autoValueVersion}")
 }
+
+sourceSets {
+    main {
+        java {
+            srcDirs = ['build/classes/java','src/main/java']
+        }
+    }
+    test {
+        java {
+            srcDirs = ['src/test/java']
+        }
+    }
+}

--- a/portability-spi-cloud/src/main/java/org/dataportabilityproject/spi/cloud/types/JobAuthorization.java
+++ b/portability-spi-cloud/src/main/java/org/dataportabilityproject/spi/cloud/types/JobAuthorization.java
@@ -61,7 +61,11 @@ public abstract class JobAuthorization {
   public abstract String encryptedPrivateKey();
 
   public static Builder builder() {
-    return new AutoValue_JobAuthorization.Builder().setState(State.INITIAL);
+    // TODO: Fix so we don't need fully qualified name here. This is to get IntelliJ to recognize
+    // the class name due to a conflict in package names for our generated code, but the conflict
+    // doesn't cause any actual problems with building.
+    return new org.dataportabilityproject.spi.cloud.types.AutoValue_JobAuthorization.Builder()
+        .setState(State.INITIAL);
   }
 
   public abstract Builder toBuilder();

--- a/portability-spi-cloud/src/main/java/org/dataportabilityproject/spi/cloud/types/PortabilityJob.java
+++ b/portability-spi-cloud/src/main/java/org/dataportabilityproject/spi/cloud/types/PortabilityJob.java
@@ -59,6 +59,9 @@ public abstract class PortabilityJob {
 
   public static PortabilityJob.Builder builder() {
     LocalDateTime now = LocalDateTime.now();
+    // TODO: Fix so we don't need fully qualified name here. This is to get IntelliJ to recognize
+    // the class name due to a conflict in package names for our generated code, but the conflict
+    // doesn't cause any actual problems with building.
     return new org.dataportabilityproject.spi.cloud.types.AutoValue_PortabilityJob.Builder()
         .setState(State.NEW)
         .setCreatedTimestamp(now)

--- a/portability-spi-cloud/src/main/java/org/dataportabilityproject/spi/cloud/types/PortabilityJob.java
+++ b/portability-spi-cloud/src/main/java/org/dataportabilityproject/spi/cloud/types/PortabilityJob.java
@@ -59,7 +59,7 @@ public abstract class PortabilityJob {
 
   public static PortabilityJob.Builder builder() {
     LocalDateTime now = LocalDateTime.now();
-    return new AutoValue_PortabilityJob.Builder()
+    return new org.dataportabilityproject.spi.cloud.types.AutoValue_PortabilityJob.Builder()
         .setState(State.NEW)
         .setCreatedTimestamp(now)
         .setLastUpdateTimestamp(now);


### PR DESCRIPTION
With this change, IntelliJ build now works without any manual adding of source roots. Invalidate caches + restart still works as well.

PortabilityJobTest still runs as well, with the test root added in build.gradle.

I think something is still slightly off with a conflict between the declared package for org.dataportabilityproject.spi.cloud.types.AutoValue_PortabilityJob and the directory structure which includes an extra main/. However, this does not affect the IntelliJ build and is only noticeable if you go into an AutoValue generated impl class.